### PR TITLE
Return unique values when converting

### DIFF
--- a/kordac/Kordac.py
+++ b/kordac/Kordac.py
@@ -9,13 +9,13 @@ class Kordac(object):
 
     def __init__(self):
         """Creates a Kordac object."""
-        kordac_extension = KordacExtension()
+        self.kordac_extension = KordacExtension()
         self.converter = markdown.Markdown(extensions=[
-        'markdown.extensions.fenced_code',
-        'markdown.extensions.codehilite',
-        'markdown.extensions.sane_lists',
-        mdx_math.MathExtension(enable_dollar_delimiter=True),
-        kordac_extension])
+            'markdown.extensions.fenced_code',
+            'markdown.extensions.codehilite',
+            'markdown.extensions.sane_lists',
+            mdx_math.MathExtension(enable_dollar_delimiter=True),
+            self.kordac_extension])
 
     def run(self, text):
         """Return a KordacResult object after converting
@@ -27,11 +27,11 @@ class Kordac(object):
         Returns:
             A KordacResult object.
         """
-        kordac_extension.heading = None
+        self.kordac_extension.heading = None
         html = self.converter.convert(text)
         result = KordacResult(
             html=html,
-            heading=kordac_extension.page_heading
+            heading=self.kordac_extension.page_heading
         )
         return result
 

--- a/kordac/Kordac.py
+++ b/kordac/Kordac.py
@@ -2,22 +2,35 @@ import markdown
 import mdx_math
 from kordac.KordacExtension import KordacExtension
 
-class Kordac():
+class Kordac(object):
+    """A converter object for converting markdown
+    to HTML"""
 
-    def run(self, md_string):
-        self.heading = 'I am a heading'
+    def run(self, markdown_string):
+        kordac_extension = KordacExtension()
+        kordac_extension.heading = None
         self.required_files = {}
-        self.html_string = ''
-        html = None
-        ext = KordacExtension()
+
         converter = markdown.Markdown(extensions=[
             'markdown.extensions.fenced_code',
             'markdown.extensions.codehilite',
             'markdown.extensions.sane_lists',
             mdx_math.MathExtension(enable_dollar_delimiter=True),
-            ext])
+            kordac_extension])
+        html = converter.convert(markdown_string)
 
-        self.html_string = converter.convert(md_string)
-        self.heading = ext.page_heading
+        result = KordacResult(
+            html=html,
+            heading=kordac_extension.page_heading
+        )
+        return result
 
-        return self
+
+class KordacResult(object):
+    """Object created by Kordac containing result of
+    a conversion by run
+    """
+
+    def __init__(self, html=None, heading=None):
+        self.html = html
+        self.heading = heading

--- a/kordac/Kordac.py
+++ b/kordac/Kordac.py
@@ -17,18 +17,18 @@ class Kordac(object):
         mdx_math.MathExtension(enable_dollar_delimiter=True),
         kordac_extension])
 
-    def run(self, markdown_string):
+    def run(self, text):
         """Return a KordacResult object after converting
         the given markdown string.
 
         Args:
-            markdown_string: A string of markdown text to be converted.
+            text: A string of Markdown text to be converted.
 
         Returns:
             A KordacResult object.
         """
         kordac_extension.heading = None
-        html = self.converter.convert(markdown_string)
+        html = self.converter.convert(text)
         result = KordacResult(
             html=html,
             heading=kordac_extension.page_heading

--- a/kordac/Kordac.py
+++ b/kordac/Kordac.py
@@ -10,6 +10,12 @@ class Kordac(object):
     def __init__(self):
         """Creates a Kordac object."""
         kordac_extension = KordacExtension()
+        self.converter = markdown.Markdown(extensions=[
+        'markdown.extensions.fenced_code',
+        'markdown.extensions.codehilite',
+        'markdown.extensions.sane_lists',
+        mdx_math.MathExtension(enable_dollar_delimiter=True),
+        kordac_extension])
 
     def run(self, markdown_string):
         """Return a KordacResult object after converting
@@ -22,15 +28,7 @@ class Kordac(object):
             A KordacResult object.
         """
         kordac_extension.heading = None
-
-        converter = markdown.Markdown(extensions=[
-            'markdown.extensions.fenced_code',
-            'markdown.extensions.codehilite',
-            'markdown.extensions.sane_lists',
-            mdx_math.MathExtension(enable_dollar_delimiter=True),
-            kordac_extension])
-        html = converter.convert(markdown_string)
-
+        html = self.converter.convert(markdown_string)
         result = KordacResult(
             html=html,
             heading=kordac_extension.page_heading

--- a/kordac/Kordac.py
+++ b/kordac/Kordac.py
@@ -4,12 +4,24 @@ from kordac.KordacExtension import KordacExtension
 
 class Kordac(object):
     """A converter object for converting markdown
-    to HTML"""
+    with complex tags to HTML.
+    """
+
+    def __init__(self):
+        """Creates a Kordac object."""
+        kordac_extension = KordacExtension()
 
     def run(self, markdown_string):
-        kordac_extension = KordacExtension()
+        """Return a KordacResult object after converting
+        the given markdown string.
+
+        Args:
+            markdown_string: A string of markdown text to be converted.
+
+        Returns:
+            A KordacResult object.
+        """
         kordac_extension.heading = None
-        self.required_files = {}
 
         converter = markdown.Markdown(extensions=[
             'markdown.extensions.fenced_code',
@@ -27,10 +39,16 @@ class Kordac(object):
 
 
 class KordacResult(object):
-    """Object created by Kordac containing result of
-    a conversion by run
+    """Object created by Kordac containing the result data
+    after a conversion by run.
     """
 
     def __init__(self, html=None, heading=None):
+        """Create a KordacResult object.
+
+        Args:
+            html: A string of HTML text.
+            heading: The first heading encountered when converting.
+        """
         self.html = html
         self.heading = heading

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='kordac',
-    version='0.0.1',
+    version='0.0.2',
     description='Kordac is an extension of the Python Markdown package, which allows authors to include complex HTML elements with simple text tags in their Markdown files.',
     url='https://github.com/uccser/kordac',
     author='UCCSER',


### PR DESCRIPTION
## Proposed changes

Return an object type of `KordacResult` which contains two values:

- `html`: A string of the resulting HTML from the conversion
- `heading`: The text of the first heading found in the conversion

Both default to `None` if no value provided.

**Related issue:** #33

### Further comments

I have also incremented the version number which makes it easier for users to tell which version of the package they have installed locally.