### PR TITLE
Add tests for save-title preprocessor

### DIFF
--- a/kordac/regex-list.json
+++ b/kordac/regex-list.json
@@ -26,7 +26,7 @@
         "pattern": "(^|\\n)(?P<level>#{1,6})(?P<header>.*?)#*(\\n|$)"
     },
     "title": {
-        "pattern": "^#+ (.*)"
+        "pattern": "^#+ ?(.*)"
     },
     "button-link": {
         "pattern": "\\{button (?P<args>[^\\}]*)\\}"

--- a/kordac/regex-list.json
+++ b/kordac/regex-list.json
@@ -26,7 +26,7 @@
         "pattern": "(^|\\n)(?P<level>#{1,6})(?P<header>.*?)#*(\\n|$)"
     },
     "title": {
-        "pattern": "# (.*)"
+        "pattern": "^#+ (.*)"
     },
     "button-link": {
         "pattern": "\\{button (?P<args>[^\\}]*)\\}"

--- a/tests/SaveTitleTest.py
+++ b/tests/SaveTitleTest.py
@@ -3,14 +3,7 @@ from kordac.processors.SaveTitlePreprocessor import SaveTitlePreprocessor
 from tests.BaseTestCase import BaseTestCase
 
 class SaveTitleTest(BaseTestCase):
-    """
-    Inline = single line comment .e.g. {comment hello you look lovely today}
-    Block = multi line comment e.g.
-        {comment}
-        hello,
-        you look lovely today.
-        {comment end}
-    """
+    """Tests to check the 'save-title' preprocesser works as intended."""
 
     def __init__(self, *args, **kwargs):
         """Set tag name in class for file names"""

--- a/tests/SaveTitleTest.py
+++ b/tests/SaveTitleTest.py
@@ -44,3 +44,10 @@ class SaveTitleTest(BaseTestCase):
         result = self.converter.run(test_string)
         converted_test_title = result.title
         self.assertIsNone(converted_test_title)
+
+    def test_level_two_heading(self):
+        test_string = self.read_test_file('level_two_heading')
+        result = self.converter.run(test_string)
+        converted_test_title = result.title
+        expected_string = self.read_expected_output_file('level_two_heading_expected').strip()
+        self.assertEqual(expected_string, converted_test_title)

--- a/tests/SaveTitleTest.py
+++ b/tests/SaveTitleTest.py
@@ -24,3 +24,10 @@ class SaveTitleTest(BaseTestCase):
         converted_test_title = result.title
         expected_string = self.read_expected_output_file('doc_example_basic_usage_expected').strip()
         self.assertEqual(expected_string, converted_test_title)
+
+    def test_multiple_headings(self):
+        test_string = self.read_test_file('multiple_headings')
+        result = self.converter.run(test_string)
+        converted_test_title = result.title
+        expected_string = self.read_expected_output_file('multiple_headings_expected').strip()
+        self.assertEqual(expected_string, converted_test_title)

--- a/tests/SaveTitleTest.py
+++ b/tests/SaveTitleTest.py
@@ -38,3 +38,9 @@ class SaveTitleTest(BaseTestCase):
         converted_test_title = result.title
         expected_string = self.read_expected_output_file('multiple_level_one_headings_expected').strip()
         self.assertEqual(expected_string, converted_test_title)
+
+    def test_no_headings(self):
+        test_string = self.read_test_file('no_headings')
+        result = self.converter.run(test_string)
+        converted_test_title = result.title
+        self.assertIsNone(converted_test_title)

--- a/tests/SaveTitleTest.py
+++ b/tests/SaveTitleTest.py
@@ -51,3 +51,9 @@ class SaveTitleTest(BaseTestCase):
         converted_test_title = result.title
         expected_string = self.read_expected_output_file('level_two_heading_expected').strip()
         self.assertEqual(expected_string, converted_test_title)
+
+    def test_no_heading_permalink(self):
+        test_string = self.read_test_file('no_heading_permalink')
+        result = self.converter.run(test_string)
+        converted_test_title = result.title
+        self.assertIsNone(converted_test_title)

--- a/tests/SaveTitleTest.py
+++ b/tests/SaveTitleTest.py
@@ -1,0 +1,26 @@
+from kordac import Kordac
+from kordac.processors.SaveTitlePreprocessor import SaveTitlePreprocessor
+from tests.BaseTestCase import BaseTestCase
+
+class SaveTitleTest(BaseTestCase):
+    """
+    Inline = single line comment .e.g. {comment hello you look lovely today}
+    Block = multi line comment e.g.
+        {comment}
+        hello,
+        you look lovely today.
+        {comment end}
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Set tag name in class for file names"""
+        BaseTestCase.__init__(self, *args, **kwargs)
+        self.tag_name = 'save-title'
+        self.converter = Kordac()
+
+    def test_basic_usage(self):
+        test_string = self.read_test_file('doc_example_basic_usage')
+        result = self.converter.run(test_string)
+        converted_test_title = result.title
+        expected_string = self.read_expected_output_file('doc_example_basic_usage_expected').strip()
+        self.assertEqual(expected_string, converted_test_title)

--- a/tests/SaveTitleTest.py
+++ b/tests/SaveTitleTest.py
@@ -45,6 +45,15 @@ class SaveTitleTest(BaseTestCase):
         converted_test_title = result.title
         self.assertIsNone(converted_test_title)
 
+    def test_no_result_processor_off(self):
+        test_string = self.read_test_file('doc_example_basic_usage')
+        new_tags = self.converter.tag_defaults()
+        new_tags.remove(self.tag_name)
+        self.converter.update_tags(new_tags)
+        result = self.converter.run(test_string)
+        converted_test_title = result.title
+        self.assertIsNone(converted_test_title)
+
     def test_level_two_heading(self):
         test_string = self.read_test_file('level_two_heading')
         result = self.converter.run(test_string)

--- a/tests/SaveTitleTest.py
+++ b/tests/SaveTitleTest.py
@@ -31,3 +31,10 @@ class SaveTitleTest(BaseTestCase):
         converted_test_title = result.title
         expected_string = self.read_expected_output_file('multiple_headings_expected').strip()
         self.assertEqual(expected_string, converted_test_title)
+
+    def test_multiple_level_one_headings(self):
+        test_string = self.read_test_file('multiple_level_one_headings')
+        result = self.converter.run(test_string)
+        converted_test_title = result.title
+        expected_string = self.read_expected_output_file('multiple_level_one_headings_expected').strip()
+        self.assertEqual(expected_string, converted_test_title)

--- a/tests/SaveTitleTest.py
+++ b/tests/SaveTitleTest.py
@@ -57,3 +57,10 @@ class SaveTitleTest(BaseTestCase):
         result = self.converter.run(test_string)
         converted_test_title = result.title
         self.assertIsNone(converted_test_title)
+
+    def test_no_space_title(self):
+        test_string = self.read_test_file('no_space_title')
+        result = self.converter.run(test_string)
+        converted_test_title = result.title
+        expected_string = self.read_expected_output_file('no_space_title_expected').strip()
+        self.assertEqual(expected_string, converted_test_title)

--- a/tests/assets/save-title/doc_example_basic_usage.md
+++ b/tests/assets/save-title/doc_example_basic_usage.md
@@ -1,0 +1,3 @@
+# Example Title
+
+This is a sentence.

--- a/tests/assets/save-title/doc_example_basic_usage_expected.html
+++ b/tests/assets/save-title/doc_example_basic_usage_expected.html
@@ -1,0 +1,1 @@
+Example Title

--- a/tests/assets/save-title/level_two_heading.md
+++ b/tests/assets/save-title/level_two_heading.md
@@ -1,0 +1,1 @@
+## Second Level Heading

--- a/tests/assets/save-title/level_two_heading_expected.html
+++ b/tests/assets/save-title/level_two_heading_expected.html
@@ -1,0 +1,1 @@
+Second Level Heading

--- a/tests/assets/save-title/multiple_headings.md
+++ b/tests/assets/save-title/multiple_headings.md
@@ -1,0 +1,15 @@
+# First Heading
+
+This is a sentence.
+
+## Second Level Heading
+
+This is a sentence.
+
+### Third Level Heading
+
+This is a sentence.
+
+#### Fourth Level Heading
+
+This is a sentence.

--- a/tests/assets/save-title/multiple_headings_expected.html
+++ b/tests/assets/save-title/multiple_headings_expected.html
@@ -1,0 +1,1 @@
+First Heading

--- a/tests/assets/save-title/multiple_level_one_headings.md
+++ b/tests/assets/save-title/multiple_level_one_headings.md
@@ -1,0 +1,15 @@
+# First Level One Heading
+
+This is a sentence.
+
+# Second Level One Heading
+
+This is a sentence.
+
+# Third Level One Heading
+
+This is a sentence.
+
+# Fourth Level One Heading
+
+This is a sentence.

--- a/tests/assets/save-title/multiple_level_one_headings_expected.html
+++ b/tests/assets/save-title/multiple_level_one_headings_expected.html
@@ -1,0 +1,1 @@
+First Level One Heading

--- a/tests/assets/save-title/no_heading_permalink.md
+++ b/tests/assets/save-title/no_heading_permalink.md
@@ -1,0 +1,1 @@
+This is a sentence with a [permalink](# invalid-link).

--- a/tests/assets/save-title/no_headings.md
+++ b/tests/assets/save-title/no_headings.md
@@ -1,0 +1,5 @@
+This is a sentence.
+
+This is another sentence.
+
+This is a third sentence.

--- a/tests/assets/save-title/no_space_title.md
+++ b/tests/assets/save-title/no_space_title.md
@@ -1,0 +1,3 @@
+#Example Title
+
+This is a sentence.

--- a/tests/assets/save-title/no_space_title_expected.html
+++ b/tests/assets/save-title/no_space_title_expected.html
@@ -1,0 +1,1 @@
+Example Title

--- a/tests/start_tests.py
+++ b/tests/start_tests.py
@@ -10,11 +10,13 @@ from tests.ImageTest import ImageTest
 from tests.VideoTest import VideoTest
 from tests.InteractiveTest import InteractiveTest
 from tests.ButtonLinkTest import ButtonLinkTest
+from tests.SaveTitleTest import SaveTitleTest
 
 
 def suite():
     # NTS what order should these go in?
     allSuites = unittest.TestSuite((
+        unittest.makeSuite(SaveTitleTest),
         # unittest.makeSuite(GlossaryLinkTest), # order of tests by cmp()
         # unittest.makeSuite(PanelTest),
         #unittest.makeSuite(CommentPreTest),


### PR DESCRIPTION
This PR adds the test suite for the `save-title` preprocessor (previously called `headingpre`).

The other test suites create a `Mock()` object, and run `markdown.markdown()` directly, but these seem unneeded. These might have been implemented before the new Kordac structure, so I've implemented these test cases in what I believe to be the most straightforward fashion. These test cases create a Kordac converter directly, and interact with it.

An issue to be created from this process is changing the read files, as they automatically append file extensions. These tests only want to match text, but I was forced to save the text in `.html` files due to the current functions. The read input/expected files should become a generic read file that requires the extension.

This is related to issue #59.