### PR TITLE
Beautify HTML output from Kordac 

### DIFF
--- a/kordac/KordacExtension.py
+++ b/kordac/KordacExtension.py
@@ -1,4 +1,5 @@
 from markdown.extensions import Extension
+import markdown.util as utils
 
 from kordac.processors.PanelBlockProcessor import PanelBlockProcessor
 from kordac.processors.CommentPreprocessor import CommentPreprocessor
@@ -12,6 +13,7 @@ from kordac.processors.SaveTitlePreprocessor import SaveTitlePreprocessor
 from kordac.processors.DjangoPostProcessor import DjangoPostProcessor
 from kordac.processors.GlossaryLinkBlockProcessor import GlossaryLinkBlockProcessor
 from kordac.processors.ButtonLinkBlockProcessor import ButtonLinkBlockProcessor
+from kordac.processors.BeautifyPostprocessor import BeautifyPostprocessor
 
 from collections import defaultdict
 from os import listdir
@@ -20,7 +22,6 @@ import re
 import json
 
 from jinja2 import Environment, PackageLoader, select_autoescape
-
 
 class KordacExtension(Extension):
     def __init__(self, tags=[], html_templates={}, *args, **kwargs):
@@ -59,6 +60,8 @@ class KordacExtension(Extension):
             if tag in processors['blockprocessors']:
                 tag_processor = processors['blockprocessors'].get(tag)
                 md.parser.blockprocessors.add(tag_processor[0], tag_processor[1], tag_processor[2])
+
+        md.postprocessors.add('beautify', BeautifyPostprocessor(md), '_end')
 
     def clear_saved_data(self):
         self.title = None

--- a/kordac/processors/BeautifyPostprocessor.py
+++ b/kordac/processors/BeautifyPostprocessor.py
@@ -1,0 +1,10 @@
+from markdown.postprocessors import Postprocessor
+from bs4 import BeautifulSoup
+
+class BeautifyPostprocessor(Postprocessor):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def run(self, text):
+        return BeautifulSoup(text, 'html.parser').prettify()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 markdown>=2.6.8
-python.markdown.math>=0.2
 bs4>=0.0.1
 Jinja2>=2.9.5
 sphinx>=1.5.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 markdown>=2.6.8
+python.markdown.math>=0.2
+beautifulsoup4>=4.5.3
 Jinja2>=2.9.5
 sphinx>=1.5.2
 sphinx_rtd_theme>=0.1.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 markdown>=2.6.8
 python.markdown.math>=0.2
-beautifulsoup4>=4.5.3
+bs4>=0.0.1
 Jinja2>=2.9.5
 sphinx>=1.5.2
 sphinx_rtd_theme>=0.1.9

--- a/tests/CommentBlockTest.py
+++ b/tests/CommentBlockTest.py
@@ -99,4 +99,3 @@ class CommentBlockTest(BaseTestCase):
 
     def test_comment_contains_inline_comment(self):
         pass
-


### PR DESCRIPTION
This pull request addresses changes for issue #64.

This beautifies the output of Kordac instead of the poorly formatted Markdown HTML. This is done by adding a Postprocessor and activating it in the `KordacExtension`. Users can minify the ouput later if they require.