### PR TITLE
Add configuration tests (fixes #74)

### DIFF
--- a/kordac/Kordac.py
+++ b/kordac/Kordac.py
@@ -34,7 +34,7 @@ class Kordac(object):
             extensions: A list of extra extensions to run on the
                 markdown package.
         """
-        self.processors = processors
+        self.processors = set(processors)
         self.html_templates = html_templates
         self.extensions = extensions
         self.create_converter()
@@ -106,7 +106,7 @@ class Kordac(object):
                 their processors are enabled. If given, all other
                 processors are skipped.
         """
-        self.processors = processors
+        self.processors = set(processors)
         self.create_converter()
 
 class KordacResult(object):

--- a/kordac/Kordac.py
+++ b/kordac/Kordac.py
@@ -3,15 +3,12 @@ from kordac.KordacExtension import KordacExtension
 
 DEFAULT_PROCESSORS = {
     'save-title',
-    'heading',
     'comment',
     'button-link',
     'panel',
-    'video',
     'image',
     'relative-link',
-    'interactive',
-    'glossary-link'
+    'boxed-text',
 }
 
 class Kordac(object):

--- a/kordac/Kordac.py
+++ b/kordac/Kordac.py
@@ -32,8 +32,8 @@ class Kordac(object):
                 markdown package.
         """
         self.processors = set(processors)
-        self.html_templates = html_templates
-        self.extensions = extensions
+        self.html_templates = dict(html_templates)
+        self.extensions = list(extensions)
         self.create_converter()
 
     def create_converter(self):

--- a/kordac/KordacExtension.py
+++ b/kordac/KordacExtension.py
@@ -91,7 +91,7 @@ class KordacExtension(Extension):
         for file in listdir(os.path.join(os.path.dirname(__file__), 'html-templates')):
             processor_name = re.search(r'(.*?).html', file).groups()[0]
             if processor_name in custom_templates:
-                templates[processor_name] = custom_templates[processor_name]
+                templates[processor_name] = env.from_string(custom_templates[processor_name])
             else:
                 templates[processor_name] = env.get_template(file)
         return templates

--- a/kordac/tests/BaseTest.py
+++ b/kordac/tests/BaseTest.py
@@ -1,0 +1,27 @@
+import unittest
+
+class BaseTest(unittest.TestCase):
+    """A base test class for individual test classes"""
+
+    def __init__(self, *args, **kwargs):
+        """Creates BaseTest Case class
+
+        Create class inheiriting from TestCase, while also storing
+        the path to test files and the maxiumum difference to display on
+        test failures.
+        """
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        self.test_file_path = 'kordac/tests/assets/{test_type}/{filename}'
+        self.maxDiff = None
+
+    def read_test_file(self, test_type, filename, strip=False):
+        """Returns a string for a given file
+
+        This function reads a file from a given filename in UTF-8 encoding.
+        """
+        file_path = self.test_file_path.format(test_type=test_type, filename=filename)
+        file_object = open(file_path, encoding="utf-8")
+        text =  file_object.read()
+        if strip:
+            text = text.rstrip('\r\n')
+        return text

--- a/kordac/tests/BoxedTextTest.py
+++ b/kordac/tests/BoxedTextTest.py
@@ -67,3 +67,30 @@ class BoxedTextTest(ProcessorTest):
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
         expected_string = self.read_test_file(self.processor_name, 'recursive_boxed_text_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
+
+    #~
+    # Doc Tests
+    #~
+
+    def test_doc_example_basic(self):
+        test_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertTrue(True in (BoxedTextBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_doc_example_override_html(self):
+        test_string = self.read_test_file(self.processor_name, 'doc_example_override_html.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertTrue(True in (BoxedTextBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
+
+        html_template = self.read_test_file(self.processor_name, 'doc_example_override_html_template.html', strip=True)
+        kordac_extension = KordacExtension([self.processor_name], html_templates={self.processor_name: html_template})
+
+        converted_test_string = markdown.markdown(test_string, extensions=[kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_override_html_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/BoxedTextTest.py
+++ b/kordac/tests/BoxedTextTest.py
@@ -3,67 +3,67 @@ from unittest.mock import Mock
 
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.BoxedTextBlockProcessor import BoxedTextBlockProcessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
 
-class BoxedTextTest(BaseTestCase):
+class BoxedTextTest(ProcessorTest):
     """
     """
 
     def __init__(self, *args, **kwargs):
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'boxed-text'
         self.ext = Mock()
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
-        self.ext.jinja_templates = {self.processor_name: BaseTestCase.loadJinjaTemplate(self, self.processor_name)}
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name)}
 
     def test_no_boxed_text(self):
-        test_string = self.read_test_file('no_boxed_text')
+        test_string = self.read_test_file(self.processor_name, 'no_boxed_text.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(all(BoxedTextBlockProcessor(self.ext, self.md.parser).test(blocks, block) == False for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('no_boxed_text_expected')
+        expected_string = self.read_test_file(self.processor_name, 'no_boxed_text_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_single_boxed_text(self):
-        test_string = self.read_test_file('single_boxed_text')
+        test_string = self.read_test_file(self.processor_name, 'single_boxed_text.md')
         blocks = self.to_blocks(test_string)
 
         processor = BoxedTextBlockProcessor(self.ext, self.md.parser)
         self.assertTrue(True in (processor.test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('single_boxed_text_expected')
+        expected_string = self.read_test_file(self.processor_name, 'single_boxed_text_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_indented_boxed_text(self):
-        test_string = self.read_test_file('indented_boxed_text')
+        test_string = self.read_test_file(self.processor_name, 'indented_boxed_text.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (BoxedTextBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('indented_boxed_text_expected')
+        expected_string = self.read_test_file(self.processor_name, 'indented_boxed_text_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_multiple_boxed_text(self):
-        test_string = self.read_test_file('multiple_boxed_text')
+        test_string = self.read_test_file(self.processor_name, 'multiple_boxed_text.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (BoxedTextBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('multiple_boxed_text_expected')
+        expected_string = self.read_test_file(self.processor_name, 'multiple_boxed_text_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_recursive_boxed_text(self):
-        test_string = self.read_test_file('recursive_boxed_text')
+        test_string = self.read_test_file(self.processor_name, 'recursive_boxed_text.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (BoxedTextBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('recursive_boxed_text_expected')
+        expected_string = self.read_test_file(self.processor_name, 'recursive_boxed_text_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/ButtonLinkTest.py
+++ b/kordac/tests/ButtonLinkTest.py
@@ -3,48 +3,48 @@ from unittest.mock import Mock
 
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.ButtonLinkBlockProcessor import ButtonLinkBlockProcessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
 
-class ButtonLinkTest(BaseTestCase):
+class ButtonLinkTest(ProcessorTest):
     """
     """
 
     def __init__(self, *args, **kwargs):
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'button-link'
         self.ext = Mock()
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
-        self.ext.jinja_templates = {self.processor_name: BaseTestCase.loadJinjaTemplate(self, self.processor_name)}
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name)}
 
     def test_no_button(self):
-        test_string = self.read_test_file('no_button')
+        test_string = self.read_test_file(self.processor_name, 'no_button.md')
         self.assertFalse(ButtonPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('no_button_expected')
+        expected_string = self.read_test_file(self.processor_name, 'no_button_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_button(self):
-        test_string = self.read_test_file('contains_button')
+        test_string = self.read_test_file(self.processor_name, 'contains_button.md')
         self.assertTrue(ButtonPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_button_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_button_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_button(self):
-        test_string = self.read_test_file('missing_end_brace')
+        test_string = self.read_test_file(self.processor_name, 'missing_end_brace.md')
         self.assertTrue(ButtonPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('missing_end_brace_expected')
+        expected_string = self.read_test_file(self.processor_name, 'missing_end_brace_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_multiple_buttons_expected(self):
-        test_string = self.read_test_file('contains_multiple_buttons')
+        test_string = self.read_test_file(self.processor_name, 'contains_multiple_buttons.md')
         self.assertTrue(ButtonPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_multiple_buttons_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_multiple_buttons_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/CommentTest.py
+++ b/kordac/tests/CommentTest.py
@@ -3,58 +3,58 @@ from unittest.mock import Mock
 
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.CommentPreprocessor import CommentPreprocessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
-class CommentTest(BaseTestCase):
+class CommentTest(ProcessorTest):
     """
     Inline = single line comment .e.g. {comment hello you look lovely today}
     """
 
     def __init__(self, *args, **kwargs):
         """Set processor name in class for file names"""
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'comment'
         self.ext = Mock()
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
 
     def test_no_inline_comment(self):
-        test_string = self.read_test_file('no_inline_comment')
+        test_string = self.read_test_file(self.processor_name, 'no_inline_comment.md')
         self.assertFalse(CommentPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('no_inline_comment_expected')
+        expected_string = self.read_test_file(self.processor_name, 'no_inline_comment_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_text_contains_the_word_comment(self):
-        test_string = self.read_test_file('text_contains_the_word_comment')
+        test_string = self.read_test_file(self.processor_name, 'text_contains_the_word_comment.md')
         self.assertFalse(CommentPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('text_contains_the_word_comment_expected')
+        expected_string = self.read_test_file(self.processor_name, 'text_contains_the_word_comment_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def tests_contains_inline_comment(self):
-        test_string = self.read_test_file('contains_inline_comment')
+        test_string = self.read_test_file(self.processor_name, 'contains_inline_comment.md')
         self.assertTrue(CommentPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_inline_comment_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_inline_comment_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_multiple_inline_comments(self):
         #NTS not counting number of matches?
-        test_string = self.read_test_file('contains_multiple_inline_comments')
+        test_string = self.read_test_file(self.processor_name, 'contains_multiple_inline_comments.md')
         self.assertTrue(CommentPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_multiple_inline_comments_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_multiple_inline_comments_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_comment_contains_comment(self):
         # We expect to match the first closing '}' to enforce simple comments
-        test_string = self.read_test_file('comment_contains_comment')
+        test_string = self.read_test_file(self.processor_name, 'comment_contains_comment.md')
         self.assertTrue(CommentPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('comment_contains_comment_expected')
+        expected_string = self.read_test_file(self.processor_name, 'comment_contains_comment_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/CommentTest.py
+++ b/kordac/tests/CommentTest.py
@@ -58,3 +58,23 @@ class CommentTest(ProcessorTest):
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
         expected_string = self.read_test_file(self.processor_name, 'comment_contains_comment_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
+
+    #~
+    # Doc Tests
+    #~
+
+    def test_doc_example_basic(self):
+        test_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage.md')
+        self.assertTrue(CommentPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_doc_example_multiple(self):
+        test_string = self.read_test_file(self.processor_name, 'doc_example_multiple_usage.md')
+        self.assertTrue(CommentPreprocessor(self.ext, self.md.parser).test(test_string), msg='"{}"'.format(test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_multiple_usage_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/ConfigurationTest.py
+++ b/kordac/tests/ConfigurationTest.py
@@ -84,3 +84,29 @@ class ConfigurationTest(unittest.TestCase):
             stored_template = kordac.kordac_extension.jinja_templates[processor_name]
             rendered_stored_template = stored_template.render()
             self.assertEqual(rendered_expected_template, rendered_stored_template)
+
+    def test_reset_templates_after_custom(self):
+        # This test doesn't do a perfect check that both templates are the same
+        # as we cannot access the raw string stored within the loaded template
+        # Instead we check if the rendered version of both is the same, however
+        # this doesn't check context variables are the same.
+        default_template_path = 'kordac/html-templates/{}.html'
+        custom_templates = {
+            'image': '<img />',
+            'boxed-text': '<div class="box"></div>'
+        }
+        kordac = Kordac(html_templates=custom_templates)
+        for processor_name, template in custom_templates.items():
+            expected_template = jinja2.Template(template)
+            rendered_expected_template = expected_template.render()
+            stored_template = kordac.kordac_extension.jinja_templates[processor_name]
+            rendered_stored_template = stored_template.render()
+            self.assertEqual(rendered_expected_template, rendered_stored_template)
+        kordac.default_templates()
+        for processor_name in custom_templates.keys():
+            default_template = open(default_template_path.format(processor_name), 'r').read()
+            expected_template = jinja2.Template(default_template)
+            rendered_expected_template = expected_template.render()
+            stored_template = kordac.kordac_extension.jinja_templates[processor_name]
+            rendered_stored_template = stored_template.render()
+            self.assertEqual(rendered_expected_template, rendered_stored_template)

--- a/kordac/tests/ConfigurationTest.py
+++ b/kordac/tests/ConfigurationTest.py
@@ -1,5 +1,6 @@
 import unittest
 from kordac import Kordac
+import jinja2
 
 class ConfigurationTest(unittest.TestCase):
     """Test configuration methods of Kordac"""
@@ -44,25 +45,42 @@ class ConfigurationTest(unittest.TestCase):
         self.assertTrue(kordac.kordac_extension.processors, processors)
 
     def test_custom_templates_on_creation(self):
+        # This test doesn't do a perfect check that both templates are the same
+        # as we cannot access the raw string stored within the loaded template
+        # Instead we check if the rendered version of both is the same, however
+        # this doesn't check context variables are the same.
         custom_templates = {
             'image': '<img />',
             'boxed-text': '<div class="box"></div>'
         }
         kordac = Kordac(html_templates=custom_templates)
         for processor_name, template in custom_templates.items():
+            expected_template = jinja2.Template(template)
+            rendered_expected_template = expected_template.render()
             stored_template = kordac.kordac_extension.jinja_templates[processor_name]
-            self.assertEqual(template, stored_template)
+            rendered_stored_template = stored_template.render()
+            self.assertEqual(rendered_expected_template, rendered_stored_template)
 
     def test_custom_templates_after_creation(self):
+        # This test doesn't do a perfect check that both templates are the same
+        # as we cannot access the raw string stored within the loaded template
+        # Instead we check if the rendered version of both is the same, however
+        # this doesn't check context variables are the same.
         kordac = Kordac()
         custom_templates = {
             'image': '<img />',
             'boxed-text': '<div class="box"></div>'
         }
         for processor_name, template in custom_templates.items():
+            expected_template = jinja2.Template(template)
+            rendered_expected_template = expected_template.render()
             stored_template = kordac.kordac_extension.jinja_templates[processor_name]
-            self.assertNotEqual(template, stored_template)
+            rendered_stored_template = stored_template.render()
+            self.assertNotEqual(rendered_expected_template, rendered_stored_template)
         kordac.update_templates(custom_templates)
         for processor_name, template in custom_templates.items():
+            expected_template = jinja2.Template(template)
+            rendered_expected_template = expected_template.render()
             stored_template = kordac.kordac_extension.jinja_templates[processor_name]
-            self.assertEqual(template, stored_template)
+            rendered_stored_template = stored_template.render()
+            self.assertEqual(rendered_expected_template, rendered_stored_template)

--- a/kordac/tests/ConfigurationTest.py
+++ b/kordac/tests/ConfigurationTest.py
@@ -1,0 +1,21 @@
+import unittest
+from kordac import Kordac
+
+class ConfigurationTest(unittest.TestCase):
+    """Test configuration methods of Kordac"""
+
+    def __init__(self, *args, **kwargs):
+        """Creates BaseTest Case class
+
+        Create class inheiriting from TestCase, while also storing
+        the path to test files and the maxiumum difference to display on
+        test failures.
+        """
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        self.test_file_path = 'kordac/tests/assets/configuration}/{}'
+        self.maxDiff = None
+
+    def test_custom_processors_on_creation(self):
+        processors = ['comment', 'image']
+        kordac = Kordac(processors=processors)
+        self.assertTrue(kordac.kordac_extension.processors, processors)

--- a/kordac/tests/ConfigurationTest.py
+++ b/kordac/tests/ConfigurationTest.py
@@ -16,6 +16,11 @@ class ConfigurationTest(unittest.TestCase):
         self.maxDiff = None
 
     def test_custom_processors_on_creation(self):
-        processors = ['comment', 'image']
+        processors = {'comment', 'image'}
         kordac = Kordac(processors=processors)
         self.assertTrue(kordac.kordac_extension.processors, processors)
+
+    def test_default_processors_on_creation(self):
+        kordac = Kordac()
+        default_processors = kordac.processor_defaults()
+        self.assertTrue(kordac.kordac_extension.processors, default_processors)

--- a/kordac/tests/ConfigurationTest.py
+++ b/kordac/tests/ConfigurationTest.py
@@ -52,3 +52,17 @@ class ConfigurationTest(unittest.TestCase):
         for processor_name, template in custom_templates.items():
             stored_template = kordac.kordac_extension.jinja_templates[processor_name]
             self.assertEqual(template, stored_template)
+
+    def test_custom_templates_after_creation(self):
+        kordac = Kordac()
+        custom_templates = {
+            'image': '<img />',
+            'boxed-text': '<div class="box"></div>'
+        }
+        for processor_name, template in custom_templates.items():
+            stored_template = kordac.kordac_extension.jinja_templates[processor_name]
+            self.assertNotEqual(template, stored_template)
+        kordac.update_templates(custom_templates)
+        for processor_name, template in custom_templates.items():
+            stored_template = kordac.kordac_extension.jinja_templates[processor_name]
+            self.assertEqual(template, stored_template)

--- a/kordac/tests/ConfigurationTest.py
+++ b/kordac/tests/ConfigurationTest.py
@@ -15,12 +15,19 @@ class ConfigurationTest(unittest.TestCase):
         self.test_file_path = 'kordac/tests/assets/configuration}/{}'
         self.maxDiff = None
 
+    def test_default_processors_on_creation(self):
+        kordac = Kordac()
+        default_processors = kordac.processor_defaults()
+        self.assertTrue(kordac.kordac_extension.processors, default_processors)
+
     def test_custom_processors_on_creation(self):
         processors = {'comment', 'image'}
         kordac = Kordac(processors=processors)
         self.assertTrue(kordac.kordac_extension.processors, processors)
 
-    def test_default_processors_on_creation(self):
+    def test_custom_processors_after_creation(self):
         kordac = Kordac()
-        default_processors = kordac.processor_defaults()
-        self.assertTrue(kordac.kordac_extension.processors, default_processors)
+        processors = kordac.processor_defaults()
+        processors.add('example_processor')
+        kordac.update_processors(processors)
+        self.assertTrue(kordac.kordac_extension.processors, processors)

--- a/kordac/tests/ConfigurationTest.py
+++ b/kordac/tests/ConfigurationTest.py
@@ -42,3 +42,13 @@ class ConfigurationTest(unittest.TestCase):
         processors.append('example_processor')
         kordac.update_processors(processors)
         self.assertTrue(kordac.kordac_extension.processors, processors)
+
+    def test_custom_templates_on_creation(self):
+        custom_templates = {
+            'image': '<img />',
+            'boxed-text': '<div class="box"></div>'
+        }
+        kordac = Kordac(html_templates=custom_templates)
+        for processor_name, template in custom_templates.items():
+            stored_template = kordac.kordac_extension.jinja_templates[processor_name]
+            self.assertEqual(template, stored_template)

--- a/kordac/tests/ConfigurationTest.py
+++ b/kordac/tests/ConfigurationTest.py
@@ -18,16 +18,27 @@ class ConfigurationTest(unittest.TestCase):
     def test_default_processors_on_creation(self):
         kordac = Kordac()
         default_processors = kordac.processor_defaults()
-        self.assertTrue(kordac.kordac_extension.processors, default_processors)
+        self.assertEqual(kordac.kordac_extension.processors, default_processors)
 
     def test_custom_processors_on_creation(self):
         processors = {'comment', 'image'}
         kordac = Kordac(processors=processors)
-        self.assertTrue(kordac.kordac_extension.processors, processors)
+        self.assertEqual(kordac.kordac_extension.processors, processors)
 
     def test_custom_processors_after_creation(self):
         kordac = Kordac()
         processors = kordac.processor_defaults()
         processors.add('example_processor')
+        kordac.update_processors(processors)
+        self.assertEqual(kordac.kordac_extension.processors, processors)
+
+    def test_unique_custom_processors(self):
+        processors = ['comment', 'comment', 'comment']
+        kordac = Kordac(processors=processors)
+        self.assertEqual(kordac.kordac_extension.processors, set(processors))
+        processors = list(kordac.processor_defaults())
+        processors.append('example_processor')
+        processors.append('example_processor')
+        processors.append('example_processor')
         kordac.update_processors(processors)
         self.assertTrue(kordac.kordac_extension.processors, processors)

--- a/kordac/tests/GlossaryLinkTest.py
+++ b/kordac/tests/GlossaryLinkTest.py
@@ -3,60 +3,60 @@ from unittest.mock import Mock
 
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.GlossaryLinkBlockProcessor import GlossaryLinkBlockProcessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
 
-class GlossaryLinkTest(BaseTestCase):
+class GlossaryLinkTest(ProcessorTest):
 
     def __init__(self, *args, **kwargs):
         """Set processor name in class for file names"""
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'glossary-link'
         self.ext = Mock()
-        self.ext.jinja_templates = {self.processor_name: BaseTestCase.loadJinjaTemplate(self, self.processor_name)}
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name)}
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
 
     def test_match_false(self):
-        test_string = self.read_test_file('fail_string')
+        test_string = self.read_test_file(self.processor_name, 'fail_string.md')
         self.assertFalse(GlossaryLinkBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
         # TODO test longer strings
 
     def test_match_single_word_term_true(self):
-        test_string = self.read_test_file('single_word_term')
+        test_string = self.read_test_file(self.processor_name, 'single_word_term.md')
         self.assertTrue(GlossaryLinkBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
 
     def test_match_multiple_word_term_true(self):
-        test_string = self.read_test_file('multiple_word_term')
+        test_string = self.read_test_file(self.processor_name, 'multiple_word_term.md')
         self.assertTrue(GlossaryLinkBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
         # TODO test more files with multiple terms
 
     def test_match_inline_true(self):
-        test_string = self.read_test_file('inline_leading_characters')
+        test_string = self.read_test_file(self.processor_name, 'inline_leading_characters.md')
         self.assertTrue(GlossaryLinkBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
-        test_string = self.read_test_file('inline_trailing_characters')
+        test_string = self.read_test_file(self.processor_name, 'inline_trailing_characters.md')
         self.assertTrue(GlossaryLinkBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
-        test_string = self.read_test_file('inline_leading_and_trailing_characters')
+        test_string = self.read_test_file(self.processor_name, 'inline_leading_and_trailing_characters.md')
         self.assertTrue(GlossaryLinkBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
 
     def test_matches_more_than_one_glossary_link_true(self):
-        test_string = self.read_test_file('multiple_terms')
+        test_string = self.read_test_file(self.processor_name, 'multiple_terms.md')
         self.assertTrue(GlossaryLinkBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
 
     # should parsing tests be in their own class?
     def test_correctly_parsed_inline(self):
-        test_string = self.read_test_file('inline_leading_characters')
+        test_string = self.read_test_file(self.processor_name, 'inline_leading_characters.md')
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension]) + '\n'
-        expected_file_string = self.read_expected_output_file('inline_leading_characters_expected')
+        expected_file_string = self.read_test_file(self.processor_name, 'inline_leading_characters_expected.html', strip=True)
         self.assertEqual(converted_test_string, expected_file_string)
 
-        test_string = self.read_test_file('inline_trailing_characters')
+        test_string = self.read_test_file(self.processor_name, 'inline_trailing_characters.md')
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension]) + '\n'
-        expected_file_string = self.read_expected_output_file('inline_trailing_characters_expected')
+        expected_file_string = self.read_test_file(self.processor_name, 'inline_trailing_characters_expected.html', strip=True)
         # self.assertEqual(converted_test_string, expected_file_string)
 
-        test_string = self.read_test_file('inline_leading_and_trailing_characters')
+        test_string = self.read_test_file(self.processor_name, 'inline_leading_and_trailing_characters.md')
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension]) + '\n'
-        expected_file_string = self.read_expected_output_file('inline_leading_and_trailing_characters_expected')
+        expected_file_string = self.read_test_file(self.processor_name, 'inline_leading_and_trailing_characters_expected.html', strip=True)
         # self.assertEqual(converted_test_string, expected_file_string)
 
     def test_glossary_link_in_panel(self):

--- a/kordac/tests/HeadingTest.py
+++ b/kordac/tests/HeadingTest.py
@@ -3,13 +3,13 @@ import markdown
 
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.NumberedHashHeaderProcessor import NumberedHashHeaderProcessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
-class HeadingTest(BaseTestCase):
+class HeadingTest(ProcessorTest):
 
     def __init__(self, *args, **kwargs):
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'heading'
         self.ext = Mock()
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
-        self.ext.jinja_templates = {self.processor_name: BaseTestCase.loadJinjaTemplate(self, self.processor_name)}
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name)}

--- a/kordac/tests/ImageTest.py
+++ b/kordac/tests/ImageTest.py
@@ -167,3 +167,44 @@ class ImageTest(ProcessorTest):
 
         self.assertTrue('pixel-diamond.png' in self.kordac_extension.required_files['images'])
         self.assertTrue('Lipsum.png' in self.kordac_extension.required_files['images'])
+
+    #~
+    # Doc Tests
+    #~
+
+    def test_doc_example_basic(self):
+        test_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertTrue(True in (ImageBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_doc_example_override_html(self):
+        test_string = self.read_test_file(self.processor_name, 'doc_example_override_html.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertTrue(True in (ImageBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
+
+        html_template = self.read_test_file(self.processor_name, 'doc_example_override_html_template.html', strip=True)
+        kordac_extension = KordacExtension([self.processor_name], html_templates={self.processor_name: html_template})
+
+        converted_test_string = markdown.markdown(test_string, extensions=[kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_override_html_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_doc_example_2_override_html(self):
+        test_string = self.read_test_file(self.processor_name, 'doc_example_2_override_html.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertTrue(True in (ImageBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
+
+        html_template = self.read_test_file(self.processor_name, 'doc_example_2_override_html_template.html', strip=True)
+        link_template = self.read_test_file(self.processor_name, 'doc_example_2_override_link_html_template.html', strip=True)
+        kordac_extension = KordacExtension([self.processor_name], html_templates={self.processor_name: html_template, 'relative-image-link': link_template})
+
+        converted_test_string = markdown.markdown(test_string, extensions=[kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_2_override_html_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/ImageTest.py
+++ b/kordac/tests/ImageTest.py
@@ -4,147 +4,147 @@ from collections import defaultdict
 
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.ImageBlockProcessor import ImageBlockProcessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
-class ImageTest(BaseTestCase):
+class ImageTest(ProcessorTest):
 
     def __init__(self, *args, **kwargs):
         """Set processor name in class for file names"""
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'image'
         self.ext = Mock()
-        self.ext.jinja_templates = {self.processor_name: BaseTestCase.loadJinjaTemplate(self, self.processor_name), 'relative-image-link': BaseTestCase.loadJinjaTemplate(self, 'relative-image-link')}
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name), 'relative-image-link': ProcessorTest.loadJinjaTemplate(self, 'relative-image-link')}
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
         self.ext.required_files = defaultdict(set)
 
     def test_internal_image(self):
-        test_string = self.read_test_file('internal_image')
+        test_string = self.read_test_file(self.processor_name, 'internal_image.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('internal_image_expected')
+        expected_string = self.read_test_file(self.processor_name, 'internal_image_expected.html', strip=True)
 
         self.assertEqual(expected_string, converted_test_string)
 
     def test_external_image(self):
-        test_string = self.read_test_file('external_image')
+        test_string = self.read_test_file(self.processor_name, 'external_image.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('external_image_expected')
+        expected_string = self.read_test_file(self.processor_name, 'external_image_expected.html', strip=True)
 
         self.assertEqual(expected_string, converted_test_string)
 
     def test_default_image(self):
-        test_string = self.read_test_file('default_image')
+        test_string = self.read_test_file(self.processor_name, 'default_image.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('default_image_expected')
+        expected_string = self.read_test_file(self.processor_name, 'default_image_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_multiple_images(self):
-        test_string = self.read_test_file('contains_multiple_images')
+        test_string = self.read_test_file(self.processor_name, 'contains_multiple_images.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_multiple_images_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_multiple_images_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_no_image(self):
-        test_string = self.read_test_file('no_image')
+        test_string = self.read_test_file(self.processor_name, 'no_image.md')
         self.assertFalse(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('no_image_expected')
+        expected_string = self.read_test_file(self.processor_name, 'no_image_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_text_contains_the_word_image(self):
-        test_string = self.read_test_file('text_contains_the_word_image')
+        test_string = self.read_test_file(self.processor_name, 'text_contains_the_word_image.md')
         self.assertFalse(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('text_contains_the_word_image_expected')
+        expected_string = self.read_test_file(self.processor_name, 'text_contains_the_word_image_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_image(self):
-        test_string = self.read_test_file('contains_image')
+        test_string = self.read_test_file(self.processor_name, 'contains_image.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_image_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_image_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_image_and_text_contains_word_image(self):
-        test_string = self.read_test_file('contains_image_and_text_contains_word_image')
+        test_string = self.read_test_file(self.processor_name, 'contains_image_and_text_contains_word_image.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_image_and_text_contains_word_image_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_image_and_text_contains_word_image_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_hover_text(self):
-        test_string = self.read_test_file('contains_hover_text')
+        test_string = self.read_test_file(self.processor_name, 'contains_hover_text.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_hover_text_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_hover_text_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_caption_link(self):
-        test_string = self.read_test_file('contains_caption_link')
+        test_string = self.read_test_file(self.processor_name, 'contains_caption_link.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_caption_link_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_caption_link_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_alt(self):
-        test_string = self.read_test_file('contains_alt')
+        test_string = self.read_test_file(self.processor_name, 'contains_alt.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_alt_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_alt_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_caption(self):
-        test_string = self.read_test_file('contains_caption')
+        test_string = self.read_test_file(self.processor_name, 'contains_caption.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_caption_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_caption_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_source(self):
-        test_string = self.read_test_file('contains_source')
+        test_string = self.read_test_file(self.processor_name, 'contains_source.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_source_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_source_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_align_left(self):
-        test_string = self.read_test_file('align_left')
+        test_string = self.read_test_file(self.processor_name, 'align_left.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('align_left_expected')
+        expected_string = self.read_test_file(self.processor_name, 'align_left_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_align_right(self):
-        test_string = self.read_test_file('align_right')
+        test_string = self.read_test_file(self.processor_name, 'align_right.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('align_right_expected')
+        expected_string = self.read_test_file(self.processor_name, 'align_right_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_align_center(self):
-        test_string = self.read_test_file('align_center')
+        test_string = self.read_test_file(self.processor_name, 'align_center.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('align_center_expected')
+        expected_string = self.read_test_file(self.processor_name, 'align_center_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     # ~
@@ -152,7 +152,7 @@ class ImageTest(BaseTestCase):
     # ~
 
     def test_internal_image_required(self):
-        test_string = self.read_test_file('internal_image')
+        test_string = self.read_test_file(self.processor_name, 'internal_image.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
@@ -160,7 +160,7 @@ class ImageTest(BaseTestCase):
         self.assertTrue('pixel-diamond.png' in self.kordac_extension.required_files['images'])
 
     def test_multiple_internal_image_required(self):
-        test_string = self.read_test_file('multiple_internal_image')
+        test_string = self.read_test_file(self.processor_name, 'multiple_internal_image.md')
         self.assertTrue(ImageBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg=''.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])

--- a/kordac/tests/InteractiveTest.py
+++ b/kordac/tests/InteractiveTest.py
@@ -3,14 +3,14 @@ import markdown
 
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.InteractiveBlockProcessor import InteractiveBlockProcessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
-class InteractiveTest(BaseTestCase):
+class InteractiveTest(ProcessorTest):
 
     def __init__(self, *args, **kwargs):
         """Set processor name in class for file names"""
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'interactive'
         self.ext = Mock()
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
-        self.ext.jinja_templates = {self.processor_name: BaseTestCase.loadJinjaTemplate(self, self.processor_name)}
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name)}

--- a/kordac/tests/PanelTest.py
+++ b/kordac/tests/PanelTest.py
@@ -109,3 +109,30 @@ class PanelTest(ProcessorTest):
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         self.assertRaises(TagNotMatchedError, lambda x: markdown.markdown(x, extensions=[self.kordac_extension]), test_string)
+
+    #~
+    # Doc Tests
+    #~
+
+    def test_doc_example_basic(self):
+        test_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_doc_example_override_html(self):
+        test_string = self.read_test_file(self.processor_name, 'doc_example_override_html.md')
+        blocks = self.to_blocks(test_string)
+
+        self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
+
+        html_template = self.read_test_file(self.processor_name, 'doc_example_override_html_template.html', strip=True)
+        kordac_extension = KordacExtension([self.processor_name], html_templates={self.processor_name: html_template})
+
+        converted_test_string = markdown.markdown(test_string, extensions=[kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_override_html_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/PanelTest.py
+++ b/kordac/tests/PanelTest.py
@@ -4,90 +4,90 @@ from unittest.mock import Mock
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.PanelBlockProcessor import PanelBlockProcessor
 from kordac.processors.errors.TagNotMatchedError import TagNotMatchedError
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
-class PanelTest(BaseTestCase):
+class PanelTest(ProcessorTest):
 
     def __init__(self, *args, **kwargs):
         """Set processor name in class for file names"""
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'panel'
         self.ext = Mock()
-        self.ext.jinja_templates = {self.processor_name: BaseTestCase.loadJinjaTemplate(self, self.processor_name)}
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name)}
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
 
     def test_parses_blank(self):
-        test_string = self.read_test_file('parses_blank')
+        test_string = self.read_test_file(self.processor_name, 'parses_blank.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(all(PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('parses_blank_expected')
+        expected_string = self.read_test_file(self.processor_name, 'parses_blank_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_parses_no_blank_lines_single_paragraph(self):
-        test_string = self.read_test_file('parses_no_blank_lines_single_paragraph')
+        test_string = self.read_test_file(self.processor_name, 'parses_no_blank_lines_single_paragraph.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('parses_no_blank_lines_single_paragraph_expected')
+        expected_string = self.read_test_file(self.processor_name, 'parses_no_blank_lines_single_paragraph_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_parses_expanded_panel(self):
-        test_string = self.read_test_file('parses_expanded_panel')
+        test_string = self.read_test_file(self.processor_name, 'parses_expanded_panel.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('parses_expanded_panel_expected')
+        expected_string = self.read_test_file(self.processor_name, 'parses_expanded_panel_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_parses_always_expanded_panel(self):
-        test_string = self.read_test_file('parses_always_expanded_panel')
+        test_string = self.read_test_file(self.processor_name, 'parses_always_expanded_panel.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('parses_always_expanded_panel_expected')
+        expected_string = self.read_test_file(self.processor_name, 'parses_always_expanded_panel_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_parses_blank_lines_multiple_paragraphs(self):
-        test_string = self.read_test_file('parses_blank_lines_multiple_paragraphs')
+        test_string = self.read_test_file(self.processor_name, 'parses_blank_lines_multiple_paragraphs.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('parses_blank_lines_multiple_paragraphs_expected')
+        expected_string = self.read_test_file(self.processor_name, 'parses_blank_lines_multiple_paragraphs_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_multiple_panels(self):
-        test_string = self.read_test_file('contains_multiple_panels')
+        test_string = self.read_test_file(self.processor_name, 'contains_multiple_panels.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_multiple_panels_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_multiple_panels_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_contains_inner_panel(self):
-        test_string = self.read_test_file('contains_inner_panel')
+        test_string = self.read_test_file(self.processor_name, 'contains_inner_panel.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('contains_inner_panel_expected')
+        expected_string = self.read_test_file(self.processor_name, 'contains_inner_panel_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_missing_start_tag(self):
-        test_string = self.read_test_file('missing_start_tag')
+        test_string = self.read_test_file(self.processor_name, 'missing_start_tag.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
@@ -95,7 +95,7 @@ class PanelTest(BaseTestCase):
         self.assertRaises(TagNotMatchedError, lambda x: markdown.markdown(x, extensions=[self.kordac_extension]), test_string)
 
     def test_missing_end_tag(self):
-        test_string = self.read_test_file('missing_end_tag')
+        test_string = self.read_test_file(self.processor_name, 'missing_end_tag.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))
@@ -103,7 +103,7 @@ class PanelTest(BaseTestCase):
         self.assertRaises(TagNotMatchedError, lambda x: markdown.markdown(x, extensions=[self.kordac_extension]), test_string)
 
     def test_missing_tag_inner(self):
-        test_string = self.read_test_file('missing_tag_inner')
+        test_string = self.read_test_file(self.processor_name, 'missing_tag_inner.md')
         blocks = self.to_blocks(test_string)
 
         self.assertTrue(True in (PanelBlockProcessor(self.ext, self.md.parser).test(blocks, block) for block in blocks), msg='"{}"'.format(test_string))

--- a/kordac/tests/ProcessorTest.py
+++ b/kordac/tests/ProcessorTest.py
@@ -4,8 +4,9 @@ import markdown
 from kordac.KordacExtension import KordacExtension
 from markdown.extensions import Extension
 from jinja2 import Environment, PackageLoader, select_autoescape
+from kordac.tests.BaseTest import BaseTest
 
-class BaseTestCase(unittest.TestCase):
+class ProcessorTest(BaseTest):
     """A base test class for individual test classes"""
 
     def __init__(self, *args, **kwargs):
@@ -15,32 +16,7 @@ class BaseTestCase(unittest.TestCase):
         the path to test files and the maxiumum difference to display on
         test failures.
         """
-        unittest.TestCase.__init__(self, *args, **kwargs)
-        self.test_file_path = 'kordac/tests/assets/{processor_name}/{filename}.md'
-        self.expected_output_file_path = 'kordac/tests/assets/{processor_name}/{filename}.html'
-        # self.maxDiff = 640  # Set to None for full output of all test failures
-        self.maxDiff = None
-
-    def read_test_file(self, filename):
-        """Returns a string for a given file
-
-        This function reads a file from a given filename in UTF-8 encoding.
-        """
-        file_path = self.test_file_path.format(processor_name=self.processor_name, filename=filename)
-        file_object = open(file_path, encoding="utf-8")
-        return file_object.read()
-
-    def read_expected_output_file(self, filename):
-        """Returns a string for a given file
-
-        This function reads a file from a given filename in UTF-8 encoding.
-        """
-        file_path = self.expected_output_file_path.format(processor_name=self.processor_name, filename=filename)
-        file_object = open(file_path, encoding="utf-8")
-        return file_object.read().rstrip('\r\n')
-
-    def loadHTMLTemplate(self, template):
-        return open('kordac/html-templates/' + template + '.html').read()
+        BaseTest.__init__(self, *args, **kwargs)
 
     def loadJinjaTemplate(self, template):
         env = Environment(

--- a/kordac/tests/RelativeLinkTest.py
+++ b/kordac/tests/RelativeLinkTest.py
@@ -3,176 +3,176 @@ import re
 from unittest.mock import Mock
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.RelativeLinkPattern import RelativeLinkPattern
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
-class RelativeLinkTest(BaseTestCase):
+class RelativeLinkTest(ProcessorTest):
     """Tests to check the 'relative-link' pattern works as intended."""
 
     def __init__(self, *args, **kwargs):
         """Set processor name in class for file names"""
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'relative-link'
         self.ext = Mock()
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
-        self.ext.jinja_templates = {self.processor_name: BaseTestCase.loadJinjaTemplate(self, self.processor_name)}
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name)}
 
     def test_basic_usage(self):
-        test_string = self.read_test_file('doc_example_basic_usage')
+        test_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('doc_example_basic_usage_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_long_path(self):
-        test_string = self.read_test_file('long_path')
+        test_string = self.read_test_file(self.processor_name, 'long_path.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('long_path_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'long_path_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_multiple_links(self):
-        test_string = self.read_test_file('multiple_links')
+        test_string = self.read_test_file(self.processor_name, 'multiple_links.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('multiple_links_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'multiple_links_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_ignore_http_schema(self):
-        test_string = self.read_test_file('http_schema')
+        test_string = self.read_test_file(self.processor_name, 'http_schema.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('http_schema_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'http_schema_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_http_text(self):
-        test_string = self.read_test_file('http_text')
+        test_string = self.read_test_file(self.processor_name, 'http_text.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('http_text_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'http_text_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_ignore_https_schema(self):
-        test_string = self.read_test_file('https_schema')
+        test_string = self.read_test_file(self.processor_name, 'https_schema.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('https_schema_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'https_schema_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_https_text(self):
-        test_string = self.read_test_file('https_text')
+        test_string = self.read_test_file(self.processor_name, 'https_text.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('https_text_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'https_text_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_ignore_ftp_schema(self):
-        test_string = self.read_test_file('ftp_schema')
+        test_string = self.read_test_file(self.processor_name, 'ftp_schema.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('ftp_schema_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'ftp_schema_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_ftp_text(self):
-        test_string = self.read_test_file('ftp_text')
+        test_string = self.read_test_file(self.processor_name, 'ftp_text.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('ftp_text_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'ftp_text_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_ignore_ftps_schema(self):
-        test_string = self.read_test_file('ftps_schema')
+        test_string = self.read_test_file(self.processor_name, 'ftps_schema.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('ftps_schema_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'ftps_schema_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_ftps_text(self):
-        test_string = self.read_test_file('ftps_text')
+        test_string = self.read_test_file(self.processor_name, 'ftps_text.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('ftps_text_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'ftps_text_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_ignore_mailto_schema(self):
-        test_string = self.read_test_file('mailto_schema')
+        test_string = self.read_test_file(self.processor_name, 'mailto_schema.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('mailto_schema_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'mailto_schema_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_mailto_text(self):
-        test_string = self.read_test_file('mailto_text')
+        test_string = self.read_test_file(self.processor_name, 'mailto_text.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('mailto_text_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'mailto_text_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
 
     def test_ignore_news_schema(self):
-        test_string = self.read_test_file('news_schema')
+        test_string = self.read_test_file(self.processor_name, 'news_schema.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('news_schema_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'news_schema_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_news_text(self):
-        test_string = self.read_test_file('news_text')
+        test_string = self.read_test_file(self.processor_name, 'news_text.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('news_text_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'news_text_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_www_text(self):
-        test_string = self.read_test_file('www_text')
+        test_string = self.read_test_file(self.processor_name, 'www_text.md')
 
         processor = RelativeLinkPattern(self.ext, self.md.parser)
         self.assertIsNotNone(re.search(processor.compiled_re, test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('www_text_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'www_text_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/RemoveTitleTest.py
+++ b/kordac/tests/RemoveTitleTest.py
@@ -2,86 +2,86 @@ import markdown
 from unittest.mock import Mock
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.RemoveTitlePreprocessor import RemoveTitlePreprocessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
-class RemoveTitleTest(BaseTestCase):
+class RemoveTitleTest(ProcessorTest):
     """Tests to check the 'remove-title' preprocesser works as intended."""
 
     def __init__(self, *args, **kwargs):
         """Set processor name in class for file names"""
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'remove-title'
         self.ext = Mock()
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
 
     def test_basic_usage(self):
-        test_string = self.read_test_file('doc_example_basic_usage')
+        test_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage.md')
 
         processor = RemoveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('doc_example_basic_usage_expected')
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_multiple_headings(self):
-        test_string = self.read_test_file('multiple_headings')
+        test_string = self.read_test_file(self.processor_name, 'multiple_headings.md')
 
         processor = RemoveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('multiple_headings_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'multiple_headings_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_multiple_level_one_headings(self):
-        test_string = self.read_test_file('multiple_level_one_headings')
+        test_string = self.read_test_file(self.processor_name, 'multiple_level_one_headings.md')
 
         processor = RemoveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('multiple_level_one_headings_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'multiple_level_one_headings_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
     def test_no_headings(self):
-        test_string = self.read_test_file('no_headings')
+        test_string = self.read_test_file(self.processor_name, 'no_headings.md')
 
         processor = RemoveTitlePreprocessor(self.ext, self.md.parser)
         self.assertFalse(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('no_headings_expected')
+        expected_string = self.read_test_file(self.processor_name, 'no_headings_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_level_two_heading(self):
-        test_string = self.read_test_file('level_two_heading')
+        test_string = self.read_test_file(self.processor_name, 'level_two_heading.md')
 
         processor = RemoveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('level_two_heading_expected')
+        expected_string = self.read_test_file(self.processor_name, 'level_two_heading_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_no_heading_permalink(self):
-        test_string = self.read_test_file('no_heading_permalink')
+        test_string = self.read_test_file(self.processor_name, 'no_heading_permalink.md')
 
         processor = RemoveTitlePreprocessor(self.ext, self.md.parser)
         self.assertFalse(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('no_heading_permalink_expected')
+        expected_string = self.read_test_file(self.processor_name, 'no_heading_permalink_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)
 
     def test_no_space_title(self):
-        test_string = self.read_test_file('no_space_title')
+        test_string = self.read_test_file(self.processor_name, 'no_space_title.md')
 
         processor = RemoveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('no_space_title_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'no_space_title_expected.html', strip=True).strip()
         self.assertEqual(expected_string, converted_test_string)
 
 
@@ -90,8 +90,8 @@ class RemoveTitleTest(BaseTestCase):
     def test_processor_off(self):
         # Create Kordac extension without processor enabled (off by default)
         kordac_extension = KordacExtension()
-        test_string = self.read_test_file('processor_off')
+        test_string = self.read_test_file(self.processor_name, 'processor_off.md')
 
         converted_test_string = markdown.markdown(test_string, extensions=[kordac_extension])
-        expected_string = self.read_expected_output_file('processor_off_expected')
+        expected_string = self.read_test_file(self.processor_name, 'processor_off_expected.html', strip=True)
         self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/SaveTitleTest.py
+++ b/kordac/tests/SaveTitleTest.py
@@ -2,50 +2,50 @@ import markdown
 from unittest.mock import Mock
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.SaveTitlePreprocessor import SaveTitlePreprocessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
-class SaveTitleTest(BaseTestCase):
+class SaveTitleTest(ProcessorTest):
     """Tests to check the 'save-title' preprocesser works as intended."""
 
     def __init__(self, *args, **kwargs):
         """Set processor name in class for file names"""
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'save-title'
         self.ext = Mock()
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
 
     def test_basic_usage(self):
-        test_string = self.read_test_file('doc_example_basic_usage')
+        test_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage.md')
 
         processor = SaveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('doc_example_basic_usage_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage_expected.html', strip=True).strip()
         self.assertEqual(expected_string, self.kordac_extension.title)
 
     def test_multiple_headings(self):
-        test_string = self.read_test_file('multiple_headings')
+        test_string = self.read_test_file(self.processor_name, 'multiple_headings.md')
 
         processor = SaveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('multiple_headings_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'multiple_headings_expected.html', strip=True).strip()
         self.assertEqual(expected_string, self.kordac_extension.title)
 
     def test_multiple_level_one_headings(self):
-        test_string = self.read_test_file('multiple_level_one_headings')
+        test_string = self.read_test_file(self.processor_name, 'multiple_level_one_headings.md')
 
         processor = SaveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('multiple_level_one_headings_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'multiple_level_one_headings_expected.html', strip=True).strip()
         self.assertEqual(expected_string, self.kordac_extension.title)
 
     def test_no_headings(self):
-        test_string = self.read_test_file('no_headings')
+        test_string = self.read_test_file(self.processor_name, 'no_headings.md')
 
         processor = SaveTitlePreprocessor(self.ext, self.md.parser)
         self.assertFalse(processor.test(test_string))
@@ -54,17 +54,17 @@ class SaveTitleTest(BaseTestCase):
         self.assertIsNone(self.kordac_extension.title)
 
     def test_level_two_heading(self):
-        test_string = self.read_test_file('level_two_heading')
+        test_string = self.read_test_file(self.processor_name, 'level_two_heading.md')
 
         processor = SaveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('level_two_heading_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'level_two_heading_expected.html', strip=True).strip()
         self.assertEqual(expected_string, self.kordac_extension.title)
 
     def test_no_heading_permalink(self):
-        test_string = self.read_test_file('no_heading_permalink')
+        test_string = self.read_test_file(self.processor_name, 'no_heading_permalink.md')
 
         processor = SaveTitlePreprocessor(self.ext, self.md.parser)
         self.assertFalse(processor.test(test_string))
@@ -73,13 +73,13 @@ class SaveTitleTest(BaseTestCase):
         self.assertIsNone(self.kordac_extension.title)
 
     def test_no_space_title(self):
-        test_string = self.read_test_file('no_space_title')
+        test_string = self.read_test_file(self.processor_name, 'no_space_title.md')
 
         processor = SaveTitlePreprocessor(self.ext, self.md.parser)
         self.assertTrue(processor.test(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_string = self.read_expected_output_file('no_space_title_expected').strip()
+        expected_string = self.read_test_file(self.processor_name, 'no_space_title_expected.html', strip=True).strip()
         self.assertEqual(expected_string, self.kordac_extension.title)
 
     # SYSTEM TESTS
@@ -87,7 +87,7 @@ class SaveTitleTest(BaseTestCase):
     def test_no_result_processor_off(self):
         # Create Kordac extension without processor enabled
         kordac_extension = KordacExtension()
-        test_string = self.read_test_file('doc_example_basic_usage')
+        test_string = self.read_test_file(self.processor_name, 'doc_example_basic_usage.md')
 
         converted_test_string = markdown.markdown(test_string, extensions=[kordac_extension])
         self.assertIsNone(kordac_extension.title)

--- a/kordac/tests/SmokeTests.py
+++ b/kordac/tests/SmokeTests.py
@@ -63,3 +63,20 @@ class SmokeFileTest(unittest.TestCase):
                 self.assertIsNot(result.title, None)
                 self.assertIsNot(result.html_string, None)
                 self.assertTrue(len(result.html_string) > 0)
+
+    def test_compile_files_custom(self):
+        custom_templates = {
+            'image': '<img />',
+            'boxed-text': '<div class="box"></div>'
+        }
+
+        kordac = Kordac(html_templates=custom_templates)
+        for chapter in ['algorithms.md', 'introduction.md']:
+            with open(self.assets_template.format(chapter), 'r') as f:
+                text = f.read()
+                result = kordac.convert(text)
+
+                self.assertIsNot(result, None)
+                self.assertIsNot(result.title, None)
+                self.assertIsNot(result.html_string, None)
+                self.assertTrue(len(result.html_string) > 0)

--- a/kordac/tests/VideoTest.py
+++ b/kordac/tests/VideoTest.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock
 
 from kordac.KordacExtension import KordacExtension
 from kordac.processors.VideoBlockProcessor import VideoBlockProcessor
-from kordac.tests.BaseTestCase import BaseTestCase
+from kordac.tests.ProcessorTest import ProcessorTest
 
 # NTS videos have different links
 # need to test:
@@ -13,46 +13,46 @@ from kordac.tests.BaseTestCase import BaseTestCase
 #   - /watch/
 # etc
 
-class VideoTest(BaseTestCase):
+class VideoTest(ProcessorTest):
 
     def __init__(self, *args, **kwargs):
         """Set processor name in class for file names"""
-        BaseTestCase.__init__(self, *args, **kwargs)
+        ProcessorTest.__init__(self, *args, **kwargs)
         self.processor_name = 'video'
         self.ext = Mock()
-        self.ext.jinja_templates = {self.processor_name: BaseTestCase.loadJinjaTemplate(self, self.processor_name)}
-        self.ext.processor_patterns = BaseTestCase.loadProcessorPatterns(self)
+        self.ext.jinja_templates = {self.processor_name: ProcessorTest.loadJinjaTemplate(self, self.processor_name)}
+        self.ext.processor_patterns = ProcessorTest.loadProcessorPatterns(self)
 
     def test_contains_no_video(self):
-        test_string = self.read_test_file('contains_no_video')
+        test_string = self.read_test_file(self.processor_name, 'contains_no_video.md')
         self.assertFalse(VideoBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_file_string = self.read_expected_output_file('contains_no_video_expected')
+        expected_file_string = self.read_test_file(self.processor_name, 'contains_no_video_expected.html', strip=True)
         self.assertEqual(converted_test_string, expected_file_string)
 
     def test_contains_youtube_video(self):
-        test_string = self.read_test_file('contains_youtube_video')
+        test_string = self.read_test_file(self.processor_name, 'contains_youtube_video.md')
         self.assertTrue(VideoBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_file_string = self.read_expected_output_file('contains_youtube_video_expected')
+        expected_file_string = self.read_test_file(self.processor_name, 'contains_youtube_video_expected.html', strip=True)
         self.assertEqual(converted_test_string, expected_file_string)
 
     def test_contains_vimeo_video(self):
-        test_string = self.read_test_file('contains_vimeo_video')
+        test_string = self.read_test_file(self.processor_name, 'contains_vimeo_video.md')
         self.assertTrue(VideoBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_file_string = self.read_expected_output_file('contains_vimeo_video_expected')
+        expected_file_string = self.read_test_file(self.processor_name, 'contains_vimeo_video_expected.html', strip=True)
         self.assertEqual(converted_test_string, expected_file_string)
 
     def test_contains_multiple_videos(self):
-        test_string = self.read_test_file('contains_multiple_videos')
+        test_string = self.read_test_file(self.processor_name, 'contains_multiple_videos.md')
         self.assertTrue(VideoBlockProcessor(self.ext, self.md.parser).test(None, test_string), msg='"{}"'.format(test_string))
 
         converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
-        expected_file_string = self.read_expected_output_file('contains_multiple_videos_expected')
+        expected_file_string = self.read_test_file(self.processor_name, 'contains_multiple_videos_expected.html', strip=True)
         self.assertEqual(converted_test_string, expected_file_string)
 
     def test_contains_another_processor(self):

--- a/kordac/tests/assets/boxed-text/doc_example_basic_usage_expected.html
+++ b/kordac/tests/assets/boxed-text/doc_example_basic_usage_expected.html
@@ -1,4 +1,10 @@
-<div>
-  <p><strong>Computer Science Report for 2.44</strong></p>
-  <p>Put your introduction to what bits are here.</p>
+<div class="boxed-text">
+ <p>
+  <strong>
+   Computer Science Report for 2.44
+  </strong>
+ </p>
+ <p>
+  Put your introduction to what bits are here.
+ </p>
 </div>

--- a/kordac/tests/assets/boxed-text/doc_example_override_html_expected.html
+++ b/kordac/tests/assets/boxed-text/doc_example_override_html_expected.html
@@ -1,5 +1,7 @@
 <div class="card">
-  <div class="card-block">
-    <p>This text is displayed using a Bootstrap 4 card.</p>
-  </div>
+ <div class="card-block">
+  <p>
+   This text is displayed using a Bootstrap 4 card.
+  </p>
+ </div>
 </div>

--- a/kordac/tests/assets/comment/doc_example_multiple_usage_expected.html
+++ b/kordac/tests/assets/comment/doc_example_multiple_usage_expected.html
@@ -1,5 +1,9 @@
-<p>Finally add a teaspoon of salt and tumeric.</p>
-
-<p>Combine and mix ingredients in a large bowl.</p>
-
-<p>Bake at 180C for 40 minutes.</p>
+<p>
+ Finally add a teaspoon of salt and tumeric.
+</p>
+<p>
+ Combine and mix ingredients in a large bowl.
+</p>
+<p>
+ Bake at 180C for 40 minutes.
+</p>

--- a/kordac/tests/assets/configuration/all_processors.md
+++ b/kordac/tests/assets/configuration/all_processors.md
@@ -1,0 +1,23 @@
+# Example Title
+
+This is a sentence.
+
+{comment This is a comment for other authors to read}
+
+Check out this [resource](resource/134).
+
+{panel type="teacher-note" title="Teacher Note" subtitle="Guides for Algorithms"}
+
+This text is the panel's contents.
+
+{panel end}
+
+{image file_path="http://placehold.it/350x150" caption="Placeholder image" source="https://placehold.it/" hover-text="This is hover text" alignment="left"}
+
+{boxed-text}
+
+**Computer Science Report for 2.44**
+
+Put your introduction to what bits are here.
+
+{boxed-text end}

--- a/kordac/tests/assets/configuration/all_processors_custom_expected.html
+++ b/kordac/tests/assets/configuration/all_processors_custom_expected.html
@@ -1,0 +1,54 @@
+<h1>
+ Example Title
+</h1>
+<p>
+ This is a sentence.
+</p>
+<p>
+ {comment This is a comment for other authors to read}
+</p>
+<p>
+ Check out this
+ <a href="resource/134">
+  resource
+ </a>
+ .
+</p>
+<div class="panel panel-teacher-note">
+ <div class="panel-header">
+  <strong>
+   Teacher Note:
+  </strong>
+  Guides for Algorithms
+ </div>
+ <div class="panel-body">
+  <p>
+   This text is the panel's contents.
+  </p>
+ </div>
+</div>
+<div>
+ <img class="left-align" src="http://placehold.it/350x150" title="This is hover text"/>
+ <p>
+  Placeholder image
+ </p>
+ <p>
+  <a href="https://placehold.it/">
+   Source
+  </a>
+ </p>
+</div>
+<p>
+ {boxed-text}
+</p>
+<p>
+ <strong>
+  Computer Science Report for 2.44
+ </strong>
+</p>
+<p>
+ Put your introduction to what bits are here.
+</p>
+<p>
+ {boxed-text end}
+</p>

--- a/kordac/tests/assets/configuration/all_processors_custom_html_expected.html
+++ b/kordac/tests/assets/configuration/all_processors_custom_html_expected.html
@@ -1,0 +1,37 @@
+<h1>
+ Example Title
+</h1>
+<p>
+ This is a sentence.
+</p>
+<p>
+ Check out this
+ <a href="{{ base_path }}resource/134">
+  resource
+ </a>
+ .
+</p>
+<div class="panel panel-teacher-note">
+ <div class="panel-header">
+  <strong>
+   Teacher Note:
+  </strong>
+  Guides for Algorithms
+ </div>
+ <div class="panel-body">
+  <p>
+   This text is the panel's contents.
+  </p>
+ </div>
+</div>
+<img class="test"/>
+<div class="box">
+ <p>
+  <strong>
+   Computer Science Report for 2.44
+  </strong>
+ </p>
+ <p>
+  Put your introduction to what bits are here.
+ </p>
+</div>

--- a/kordac/tests/assets/configuration/all_processors_except_comment_expected.html
+++ b/kordac/tests/assets/configuration/all_processors_except_comment_expected.html
@@ -1,0 +1,50 @@
+<h1>
+ Example Title
+</h1>
+<p>
+ This is a sentence.
+</p>
+<p>
+ {comment This is a comment for other authors to read}
+</p>
+<p>
+ Check out this
+ <a href="{{ base_path }}resource/134">
+  resource
+ </a>
+ .
+</p>
+<div class="panel panel-teacher-note">
+ <div class="panel-header">
+  <strong>
+   Teacher Note:
+  </strong>
+  Guides for Algorithms
+ </div>
+ <div class="panel-body">
+  <p>
+   This text is the panel's contents.
+  </p>
+ </div>
+</div>
+<div>
+ <img class="left-align" src="http://placehold.it/350x150" title="This is hover text"/>
+ <p>
+  Placeholder image
+ </p>
+ <p>
+  <a href="https://placehold.it/">
+   Source
+  </a>
+ </p>
+</div>
+<div class="boxed-text">
+ <p>
+  <strong>
+   Computer Science Report for 2.44
+  </strong>
+ </p>
+ <p>
+  Put your introduction to what bits are here.
+ </p>
+</div>

--- a/kordac/tests/assets/configuration/all_processors_expected.html
+++ b/kordac/tests/assets/configuration/all_processors_expected.html
@@ -1,0 +1,47 @@
+<h1>
+ Example Title
+</h1>
+<p>
+ This is a sentence.
+</p>
+<p>
+ Check out this
+ <a href="{{ base_path }}resource/134">
+  resource
+ </a>
+ .
+</p>
+<div class="panel panel-teacher-note">
+ <div class="panel-header">
+  <strong>
+   Teacher Note:
+  </strong>
+  Guides for Algorithms
+ </div>
+ <div class="panel-body">
+  <p>
+   This text is the panel's contents.
+  </p>
+ </div>
+</div>
+<div>
+ <img class="left-align" src="http://placehold.it/350x150" title="This is hover text"/>
+ <p>
+  Placeholder image
+ </p>
+ <p>
+  <a href="https://placehold.it/">
+   Source
+  </a>
+ </p>
+</div>
+<div class="boxed-text">
+ <p>
+  <strong>
+   Computer Science Report for 2.44
+  </strong>
+ </p>
+ <p>
+  Put your introduction to what bits are here.
+ </p>
+</div>

--- a/kordac/tests/assets/configuration/custom_processors_expected.html
+++ b/kordac/tests/assets/configuration/custom_processors_expected.html
@@ -1,0 +1,54 @@
+<h1>
+ Example Title
+</h1>
+<p>
+ This is a sentence.
+</p>
+<p>
+ {comment This is a comment for other authors to read}
+</p>
+<p>
+ Check out this
+ <a href="resource/134">
+  resource
+ </a>
+ .
+</p>
+<div class="panel panel-teacher-note">
+ <div class="panel-header">
+  <strong>
+   Teacher Note:
+  </strong>
+  Guides for Algorithms
+ </div>
+ <div class="panel-body">
+  <p>
+   This text is the panel's contents.
+  </p>
+ </div>
+</div>
+<div>
+ <img class="left-align" src="http://placehold.it/350x150" title="This is hover text"/>
+ <p>
+  Placeholder image
+ </p>
+ <p>
+  <a href="https://placehold.it/">
+   Source
+  </a>
+ </p>
+</div>
+<p>
+ {boxed-text}
+</p>
+<p>
+ <strong>
+  Computer Science Report for 2.44
+ </strong>
+</p>
+<p>
+ Put your introduction to what bits are here.
+</p>
+<p>
+ {boxed-text end}
+</p>

--- a/kordac/tests/assets/image/doc_example_2_override_html_expected.html
+++ b/kordac/tests/assets/image/doc_example_2_override_html_expected.html
@@ -1,1 +1,1 @@
-<img src="https://www.example.com/images/apple.png">
+<img src="https://www.example.com/images/apple.png"/>

--- a/kordac/tests/assets/image/doc_example_2_override_html_template.html
+++ b/kordac/tests/assets/image/doc_example_2_override_html_template.html
@@ -1,1 +1,1 @@
-<img src="{{ file_path }}">
+<img src="{{ file_path }}"/>

--- a/kordac/tests/assets/image/doc_example_basic_usage.md
+++ b/kordac/tests/assets/image/doc_example_basic_usage.md
@@ -1,1 +1,1 @@
-{image file_path="http://placehold.it/350x150" caption="Placeholder image" source="https://placehold.it/" title="This is hover text" alignment="left"}
+{image file_path="http://placehold.it/350x150" caption="Placeholder image" source="https://placehold.it/" hover-text="This is hover text" alignment="left"}

--- a/kordac/tests/assets/image/doc_example_basic_usage_expected.html
+++ b/kordac/tests/assets/image/doc_example_basic_usage_expected.html
@@ -1,5 +1,11 @@
 <div>
-  <img src="http://placehold.it/350x150" title="This is hover text" class="float-left"/>
-  <p>Placeholder image</p>
-  <p><a href="https://placehold.it/">Source</a></p>
+ <img class="left-align" src="http://placehold.it/350x150" title="This is hover text"/>
+ <p>
+  Placeholder image
+ </p>
+ <p>
+  <a href="https://placehold.it/">
+   Source
+  </a>
+ </p>
 </div>

--- a/kordac/tests/assets/image/doc_example_override_html_expected.html
+++ b/kordac/tests/assets/image/doc_example_override_html_expected.html
@@ -1,3 +1,3 @@
 <div class="text-center">
-  <img src="http://placehold.it/350x150" class="rounded img-thumbnail">
+ <img class="rounded img-thumbnail" src="http://placehold.it/350x150"/>
 </div>

--- a/kordac/tests/assets/image/doc_example_override_html_template.html
+++ b/kordac/tests/assets/image/doc_example_override_html_template.html
@@ -1,3 +1,3 @@
 <div class="text-center">
-  <img src="{{ file_path }}" class="rounded img-thumbnail">
+  <img src="{{ file_path }}" class="rounded img-thumbnail"/>
 </div>

--- a/kordac/tests/assets/panel/doc_example_basic_usage_expected.html
+++ b/kordac/tests/assets/panel/doc_example_basic_usage_expected.html
@@ -1,8 +1,13 @@
-<div class='panel panel-teacher-note'>
-  <div class='panel-header'>
-    <strong>Teacher Note:</strong> Curriculum guides for Algorithms
-  </div>
-  <div class='panel-body'>
-    <p>This text is the panel's contents.</p>
-  </div>
+<div class="panel panel-teacher-note">
+ <div class="panel-header">
+  <strong>
+   Teacher Note:
+  </strong>
+  Curriculum guides for Algorithms
+ </div>
+ <div class="panel-body">
+  <p>
+   This text is the panel's contents.
+  </p>
+ </div>
 </div>

--- a/kordac/tests/assets/panel/doc_example_override_html_expected.html
+++ b/kordac/tests/assets/panel/doc_example_override_html_expected.html
@@ -1,12 +1,16 @@
 <div class="card">
-  <div class="card-header">
-    <h5 class="mb-0">
-      <strong>Note</strong>
-    </h5>
+ <div class="card-header">
+  <h5 class="mb-0">
+   <strong>
+    Note
+   </strong>
+  </h5>
+ </div>
+ <div class="collapse show">
+  <div class="card-block">
+   <p>
+    This panel uses Bootstrap 4 card structure.
+   </p>
   </div>
-  <div class="collapse show">
-    <div class="card-block">
-      <p>This panel uses Bootstrap 4 card structure.</p>
-    </div>
-  </div>
+ </div>
 </div>

--- a/kordac/tests/start_tests.py
+++ b/kordac/tests/start_tests.py
@@ -21,6 +21,12 @@ def parse_args():
         usage='Run the command `python -m kordac.tests.start_tests` from the level above the kordac directory.', description="Verifies that Kordac is functional compared to the testing suite.")
     opts.add_option('--travis',
         action='store_true', help='Enables skipping suites on failure. To be used by continuous integration system.', default=False)
+    opts.add_option('--no_smoke',
+        action='store_true', help='Skips smoke tests, should be used for local development only.', default=False)
+    opts.add_option('--no_system',
+        action='store_true', help='Skips system tests, should be used for local development only.', default=False)
+    opts.add_option('--no_unit',
+        action='store_true', help='Skips unit tests, should be used for local development only.', default=False)
     options, arguments = opts.parse_args()
 
     return options, arguments
@@ -58,19 +64,24 @@ if __name__ == '__main__':
     options, arguments = parse_args()
 
     runner = unittest.TextTestRunner()
-    print("Running Smoke Tests")
-    result = runner.run(smoke_suite())
-    print()
+    result = None
 
-    if options.travis and not result.wasSuccessful():
+    if not options.no_smoke:
+        print("Running Smoke Tests")
+        result = runner.run(smoke_suite())
+        print()
+
+    if options.travis and result and not result.wasSuccessful():
         print("Skipping other test-suites.")
         sys.exit(1)
         print()
 
-    print("Running System Tests")
-    runner.run(system_suite())
-    print()
+    if not options.no_system:
+        print("Running System Tests")
+        runner.run(system_suite())
+        print()
 
-    print("Running Unit Tests")
-    runner.run(unit_suite())
-    print()
+    if not options.no_unit:
+        print("Running Unit Tests")
+        runner.run(unit_suite())
+        print()

--- a/kordac/tests/start_tests.py
+++ b/kordac/tests/start_tests.py
@@ -2,6 +2,7 @@ import sys, unittest, optparse
 from collections import defaultdict
 
 from kordac.tests.SmokeTests import SmokeFileTest, SmokeDocsTest
+from kordac.tests.ConfigurationTest import ConfigurationTest
 from kordac.tests.GlossaryLinkTest import GlossaryLinkTest
 from kordac.tests.PanelTest import PanelTest
 from kordac.tests.CommentTest import CommentTest
@@ -28,6 +29,11 @@ def smoke_suite():
     return unittest.TestSuite((
         unittest.makeSuite(SmokeDocsTest),
         unittest.makeSuite(SmokeFileTest),
+    ))
+
+def configuration_suite():
+    return unittest.TestSuite((
+        unittest.makeSuite(ConfigurationTest)
     ))
 
 def unit_suite():
@@ -60,6 +66,9 @@ if __name__ == '__main__':
         print("Skipping other test-suites.")
         sys.exit(1)
     print()
+
+    print("Running Configuration Tests")
+    runner.run(configuration_suite())
 
     print("Running Unit Tests")
     runner.run(unit_suite())

--- a/kordac/tests/start_tests.py
+++ b/kordac/tests/start_tests.py
@@ -31,7 +31,7 @@ def smoke_suite():
         unittest.makeSuite(SmokeFileTest),
     ))
 
-def configuration_suite():
+def system_suite():
     return unittest.TestSuite((
         unittest.makeSuite(ConfigurationTest)
     ))
@@ -65,10 +65,12 @@ if __name__ == '__main__':
     if options.travis and not result.wasSuccessful():
         print("Skipping other test-suites.")
         sys.exit(1)
-    print()
+        print()
 
-    print("Running Configuration Tests")
-    runner.run(configuration_suite())
+    print("Running System Tests")
+    runner.run(system_suite())
+    print()
 
     print("Running Unit Tests")
     runner.run(unit_suite())
+    print()

--- a/kordac/tests/start_tests.py
+++ b/kordac/tests/start_tests.py
@@ -78,10 +78,13 @@ if __name__ == '__main__':
 
     if not options.no_system:
         print("Running System Tests")
-        runner.run(system_suite())
+        system_result = runner.run(system_suite())
         print()
 
     if not options.no_unit:
         print("Running Unit Tests")
-        runner.run(unit_suite())
+        unit_result = runner.run(unit_suite())
         print()
+
+    if not system_result.wasSuccessful() or not unit_result.wasSuccessful():
+        sys.exit(1)


### PR DESCRIPTION
This pull request adds configuration tests. Testing processor changes was easy, but I haven't found a way to test changes in HTML templates within KordacExtension. This is because the templates are stored as `jinja2.Template` objects, which don't have a `__str__` function (or not one that I found).

Therefore I render both the stored and expected templates and check equality. However this can't check if the templates contain the same variables (or any!). However I feel the current solution is better than never checking at all. In the future it would be worth implementing a function that checks the given custom HTML templates contain all the required fields.

Also this fixes a bug where custom templates were not being saved as valid Template objects for use by processors.