### PR TITLE
Add file linking to button-link processor

### DIFF
--- a/docs/source/processors/button-link.rst
+++ b/docs/source/processors/button-link.rst
@@ -6,23 +6,52 @@ Button Link
 You can create a link on a button using the following text tag:
 
 .. literalinclude:: ../../../kordac/tests/assets/button-link/doc_example_basic_usage.md
-   :language: none
+    :language: none
 
 Required Tag Parameters
 ***************************************
 
-- ``link`` - The URL to link to. *Note: If the given link is a relative, a placeholder for Django to prepend the root is outputted.*
+- ``link`` - The URL to link to.
+
+    - If the given link is a relative, a placeholder for Django to prepend the root is outputted.
+    - If the ``file`` parameter is set to ``yes``, then the link will be rendered with a Django static command. See ``file`` parameter below.
 - ``text`` - Text to display on the button.
+
+Optional Tag Parameters
+***************************************
+
+- ``file`` - If set to ``yes`` the link will be rendered with a Django static command. This is useful if you wish to create a button link to a file or image.
+
+    - For example, the link ``files/python-sort-example.py`` would be rendered as ``{% static 'files/python-sort-example.py' %}``. This can be overriden, see the override section below.:
 
 The default HTML for button links is:
 
 .. literalinclude:: ../../../kordac/html-templates/button-link.html
-   :language: css+jinja
+    :language: css+jinja
 
-Using the example tag above, the resulting HTML would be:
+**Example 1**
+
+Using the following tag:
+
+.. literalinclude:: ../../../kordac/tests/assets/button-link/doc_example_basic_usage.md
+    :language: none
+
+The resulting HTML would be:
 
 .. literalinclude:: ../../../kordac/tests/assets/button-link/doc_example_basic_usage_expected.html
-   :language: html
+    :language: html
+
+**Example 2**
+
+Using the following tag:
+
+.. literalinclude:: ../../../kordac/tests/assets/button-link/doc_example_file_usage.md
+    :language: none
+
+The resulting HTML would be:
+
+.. literalinclude:: ../../../kordac/tests/assets/button-link/doc_example_file_usage_expected.html
+    :language: css+jinja
 
 Overriding HTML for Button Link
 ***************************************
@@ -32,19 +61,24 @@ When overriding the HTML for button links, the following Jinja2 placeholders are
 - ``{{ link }}`` - The URL.
 - ``{{ text }}`` - Text to display on the button.
 
+If the ``file`` parameter is set to ``yes``, the link is passed through the ``relative-image-link.html`` template. The default HTML for relative images is:
+
+.. literalinclude:: ../../../kordac/html-templates/relative-image-link.html
+  :language: css+jinja
+
 **Example**
 
 For example, providing the following HTML:
 
 .. literalinclude:: ../../../kordac/tests/assets/button-link/doc_example_override_html_template.html
-   :language: css+jinja
+    :language: css+jinja
 
 with the following tag:
 
 .. literalinclude:: ../../../kordac/tests/assets/button-link/doc_example_override_html.md
-   :language: none
+    :language: none
 
 would result in:
 
 .. literalinclude:: ../../../kordac/tests/assets/button-link/doc_example_override_html_expected.html
-   :language: html
+    :language: html

--- a/kordac/tests/assets/button-link/doc_example_file_usage.md
+++ b/kordac/tests/assets/button-link/doc_example_file_usage.md
@@ -1,0 +1,1 @@
+{button-link link="files/python-sort-example.py" text="Download Python Sorting Example" file="yes"}

--- a/kordac/tests/assets/button-link/doc_example_file_usage_expected.html
+++ b/kordac/tests/assets/button-link/doc_example_file_usage_expected.html
@@ -1,0 +1,3 @@
+<a class='button' href='{% static 'files/python-sort-example.py' %}'>
+ Download Python Sorting Example
+</a>


### PR DESCRIPTION
The planned `file` processor (#11) has nearly identical logic/templates to the `button-link` processor (#25). Instead of duplicating processors, this PR details a new parameter for the `button-link` processor to handle linking to files.

If this is accepted, the `file` processor will not need to be implemented.

If this is accepted, I also propose changing the file `relative-image-link.html` to `relative-file-link.html`, as file is a generic term.