### PR TITLE
Add documentation for table-of-contents tag

### DIFF
--- a/docs/source/processors/index.rst
+++ b/docs/source/processors/index.rst
@@ -23,4 +23,5 @@ The following pages covers how to use the available processors within Markdown t
     panel
     remove-title
     save-title
+    table-of-contents
     video

--- a/docs/source/processors/table-of-contents.rst
+++ b/docs/source/processors/table-of-contents.rst
@@ -1,0 +1,55 @@
+Table of Contents
+#######################################
+
+**Processor name:** ``table-of-contents``
+
+You can create a placeholder for a web framework (for example: Django) to
+insert a table of contents by using the following tag:
+
+.. literalinclude:: ../../../kordac/tests/assets/table-of-contents/doc_example_basic_usage.md
+    :language: none
+
+Tag Parameters
+***************************************
+
+There are no required or optional tag parameters for table of contents.
+
+**Example**
+
+Using the following tag:
+
+.. literalinclude:: ../../../kordac/tests/assets/table-of-contents/doc_example_basic_usage.md
+    :language: none
+
+The resulting HTML would be:
+
+.. literalinclude:: ../../../kordac/tests/assets/table-of-contents/doc_example_basic_usage_expected.html
+    :language: html
+
+Overriding HTML for Table of Contents
+***************************************
+
+There are no Jinja2 placeholders available when overriding the HTML for table
+of contents.
+
+The default HTML for table of contents is:
+
+.. literalinclude:: ../../../kordac/html-templates/table-of-contents.html
+   :language: css+jinja
+
+**Example**
+
+For example, providing the following HTML:
+
+.. literalinclude:: ../../../kordac/tests/assets/table-of-contents/doc_example_override_html_template.html
+    :language: css+jinja
+
+with the following tag:
+
+.. literalinclude:: ../../../kordac/tests/assets/table-of-contents/doc_example_override_html.md
+    :language: none
+
+would result in:
+
+.. literalinclude:: ../../../kordac/tests/assets/table-of-contents/doc_example_override_html_expected.html
+    :language: html

--- a/kordac/html-templates/table-of-contents.html
+++ b/kordac/html-templates/table-of-contents.html
@@ -1,0 +1,1 @@
+{{ "{{ table_of_contents }}" }}

--- a/kordac/tests/assets/table-of-contents/doc_example_basic_usage.md
+++ b/kordac/tests/assets/table-of-contents/doc_example_basic_usage.md
@@ -1,0 +1,1 @@
+{table-of-contents}

--- a/kordac/tests/assets/table-of-contents/doc_example_basic_usage_expected.html
+++ b/kordac/tests/assets/table-of-contents/doc_example_basic_usage_expected.html
@@ -1,0 +1,1 @@
+{{ table_of_contents }}

--- a/kordac/tests/assets/table-of-contents/doc_example_override_html.md
+++ b/kordac/tests/assets/table-of-contents/doc_example_override_html.md
@@ -1,0 +1,1 @@
+{table-of-contents}

--- a/kordac/tests/assets/table-of-contents/doc_example_override_html_expected.html
+++ b/kordac/tests/assets/table-of-contents/doc_example_override_html_expected.html
@@ -1,0 +1,10 @@
+<div class="toc">
+ <strong>
+  Table of Contents
+ </strong>
+ <ul>
+ {% for heading in headings %}
+ <li><a href="#{{ heading.id }}">{{ heading.name }}</a></li>
+ {% endfor %}
+ </ul>
+</div>

--- a/kordac/tests/assets/table-of-contents/doc_example_override_html_template.html
+++ b/kordac/tests/assets/table-of-contents/doc_example_override_html_template.html
@@ -1,0 +1,10 @@
+<div class="toc">
+  <strong>Table of Contents</strong>
+  <ul>
+    {% raw %}
+      {% for heading in headings %}
+        <li><a href="#{{ heading.id }}">{{ heading.name }}</a></li>
+      {% endfor %}
+    {% endraw %}
+  </ul>
+</div>


### PR DESCRIPTION
This PR adds documentation for table of contents tag, plus HTML template and basic test cases.
These may not be correct as processor is not yet implemented, so may require changing after implementation.