### PR TITLE
Add documentation for iframe tag

### DIFF
--- a/docs/source/processors/iframe.rst
+++ b/docs/source/processors/iframe.rst
@@ -11,7 +11,7 @@ You can embed a link within an ``iframe`` using the following text tag:
 Required Tag Parameters
 ***************************************
 
-- ``link`` - The URL to embed within the ``iframe``.
+- ``link`` - The URL to embed within the ``iframe`` element.
 
 The default HTML for iframe is:
 
@@ -28,4 +28,28 @@ Using the following tag:
 The resulting HTML would be:
 
 .. literalinclude:: ../../../kordac/tests/assets/iframe/doc_example_basic_usage_expected.html
+    :language: html
+
+Overriding HTML for Emedding iframes
+***************************************
+
+When overriding the HTML for iframes, the following Jinja2 placeholders are available:
+
+- ``{{ link }}`` - The URL to embed within the ``iframe`` element.
+
+**Example**
+
+For example, providing the following HTML:
+
+.. literalinclude:: ../../../kordac/tests/assets/iframe/doc_example_override_html_template.html
+    :language: css+jinja
+
+with the following tag:
+
+.. literalinclude:: ../../../kordac/tests/assets/iframe/doc_example_override_html.md
+    :language: none
+
+would result in:
+
+.. literalinclude:: ../../../kordac/tests/assets/iframe/doc_example_override_html_expected.html
     :language: html

--- a/docs/source/processors/iframe.rst
+++ b/docs/source/processors/iframe.rst
@@ -1,0 +1,31 @@
+Embed iframe
+#######################################
+
+**Processor name:** ``iframe``
+
+You can embed a link within an ``iframe`` using the following text tag:
+
+.. literalinclude:: ../../../kordac/tests/assets/iframe/doc_example_basic_usage.md
+    :language: none
+
+Required Tag Parameters
+***************************************
+
+- ``link`` - The URL to embed within the ``iframe``.
+
+The default HTML for iframe is:
+
+.. literalinclude:: ../../../kordac/html-templates/iframe.html
+    :language: css+jinja
+
+**Example**
+
+Using the following tag:
+
+.. literalinclude:: ../../../kordac/tests/assets/iframe/doc_example_basic_usage.md
+    :language: none
+
+The resulting HTML would be:
+
+.. literalinclude:: ../../../kordac/tests/assets/iframe/doc_example_basic_usage_expected.html
+    :language: html

--- a/docs/source/processors/index.rst
+++ b/docs/source/processors/index.rst
@@ -17,6 +17,7 @@ The following pages covers how to use the available processors within Markdown t
     button-link
     comment
     conditional
+    iframe
     glossary-link
     heading
     image

--- a/kordac/html-templates/iframe.html
+++ b/kordac/html-templates/iframe.html
@@ -1,0 +1,5 @@
+<iframe src="{{ link }}">
+ <p>
+  Your browser does not support iframes.
+ </p>
+</iframe>

--- a/kordac/tests/assets/iframe/doc_example_basic_usage.md
+++ b/kordac/tests/assets/iframe/doc_example_basic_usage.md
@@ -1,0 +1,1 @@
+{iframe link="http://www.google.com"}

--- a/kordac/tests/assets/iframe/doc_example_basic_usage_expected.html
+++ b/kordac/tests/assets/iframe/doc_example_basic_usage_expected.html
@@ -1,0 +1,5 @@
+<iframe src="http://www.google.com">
+ <p>
+  Your browser does not support iframes.
+ </p>
+</iframe>

--- a/kordac/tests/assets/iframe/doc_example_override_html.md
+++ b/kordac/tests/assets/iframe/doc_example_override_html.md
@@ -1,0 +1,1 @@
+{iframe link="https://github.com/"}

--- a/kordac/tests/assets/iframe/doc_example_override_html_expected.html
+++ b/kordac/tests/assets/iframe/doc_example_override_html_expected.html
@@ -1,0 +1,1 @@
+<iframe src="https://github.com/" class="embed-iframe" width="400" height="300" frameborder="0"></iframe>

--- a/kordac/tests/assets/iframe/doc_example_override_html_template.html
+++ b/kordac/tests/assets/iframe/doc_example_override_html_template.html
@@ -1,0 +1,1 @@
+<iframe src="{{ link }}" class="embed-iframe" width="400" height="300" frameborder="0"></iframe>


### PR DESCRIPTION
This PR adds documentation for the iframe tag, plus HTML template and basic test cases.
These may not be correct as processor is not yet implemented, so may require changing after implementation.