### PR TITLE
Stop inline code tags from beautifying.

### DIFF
--- a/kordac/processors/BeautifyPostprocessor.py
+++ b/kordac/processors/BeautifyPostprocessor.py
@@ -1,10 +1,53 @@
 from markdown.postprocessors import Postprocessor
+from markdown.util import HtmlStash
+from markdown.odict import OrderedDict
 from bs4 import BeautifulSoup
+import re
 
 class BeautifyPostprocessor(Postprocessor):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.pre_pattern = re.compile(r'<pre>.*?</pre>', re.DOTALL)
+        self.code_pattern = re.compile(r'<code>(?P<code>.*?)</code>', re.DOTALL)
+        self.html_stash = HtmlStash()
 
     def run(self, text):
-        return BeautifulSoup(text, 'html.parser').prettify()
+        text = self.store_non_pre_code_tags(text)
+        text = BeautifulSoup(text, 'html.parser').prettify()  # Could use `formatter="html"`
+        text = self.restore_non_pre_code_tags(text)
+        return text
+
+    def store_non_pre_code_tags(self, text):
+        prepass_text = text
+        pre_spans = []
+
+        match = self.pre_pattern.search(prepass_text)
+        while match is not None:
+            pre_spans.append(match.span())
+            prepass_text = prepass_text[match.end():]
+            match = self.pre_pattern.search(prepass_text)
+
+        out_text = ''
+        match = self.code_pattern.search(text)
+        while match is not None:
+            html_string = match.group()
+            placeholder = self.html_stash.store(html_string, True)
+            out_text = text[:match.start()] + placeholder
+            text = text[match.end():]
+            match = self.pre_pattern.search(text)
+        out_text += text
+
+        return out_text
+
+    def restore_non_pre_code_tags(self, text):
+        replacements = OrderedDict()
+        for i in range(self.html_stash.html_counter):
+            html, safe = self.html_stash.rawHtmlBlocks[i]
+            replacements[self.html_stash.get_placeholder(i)] = html
+
+        if len(replacements) > 0:
+            pattern = re.compile("|".join(re.escape(k) for k in replacements))
+            text = pattern.sub(lambda m: replacements[m.group(0)], text)
+
+        return text

--- a/kordac/processors/BeautifyPostprocessor.py
+++ b/kordac/processors/BeautifyPostprocessor.py
@@ -31,9 +31,12 @@ class BeautifyPostprocessor(Postprocessor):
         out_text = ''
         match = self.code_pattern.search(text)
         while match is not None:
-            html_string = match.group()
-            placeholder = self.html_stash.store(html_string, True)
-            out_text = text[:match.start()] + placeholder
+            if not any(match.start() in range(*span) or match.end() in range(*span) for span in pre_spans):
+                html_string = match.group()
+                placeholder = self.html_stash.store(html_string, True)
+                out_text = text[:match.start()] + placeholder
+            else:
+                out_text = text[:match.end()]
             text = text[match.end():]
             match = self.pre_pattern.search(text)
         out_text += text

--- a/kordac/tests/BeautifyTest.py
+++ b/kordac/tests/BeautifyTest.py
@@ -1,0 +1,41 @@
+import markdown
+from unittest.mock import Mock
+
+from kordac.KordacExtension import KordacExtension
+from kordac.processors.CommentPreprocessor import CommentPreprocessor
+from kordac.tests.ProcessorTest import ProcessorTest
+
+class BeautifyTest(ProcessorTest):
+    def __init__(self, *args, **kwargs):
+        """Set processor name in class for file names"""
+        ProcessorTest.__init__(self, *args, **kwargs)
+        self.processor_name = 'beautify'
+
+    def test_example_inline_code(self):
+        test_string = self.read_test_file(self.processor_name, 'example_inline_code.md')
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'example_inline_code_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_example_preformatted_code(self):
+        test_string = self.read_test_file(self.processor_name, 'example_preformatted_code.md')
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'example_preformatted_code_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+    def test_example_preformatted_code_with_extension(self):
+        kordac_extension = KordacExtension([self.processor_name], {}, ['markdown.extensions.fenced_code'])
+        test_string = self.read_test_file(self.processor_name, 'example_preformatted_code_with_extension.md')
+
+        converted_test_string = markdown.markdown(test_string, extensions=[kordac_extension, 'markdown.extensions.fenced_code'])
+        expected_string = self.read_test_file(self.processor_name, 'example_preformatted_code_with_extension_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)
+
+    def text_example_mixed_code_types(self):
+        test_string = self.read_test_file(self.processor_name, 'example_mixed_code_types.md')
+
+        converted_test_string = markdown.markdown(test_string, extensions=[self.kordac_extension])
+        expected_string = self.read_test_file(self.processor_name, 'example_mixed_code_types_expected.html', strip=True)
+        self.assertEqual(expected_string, converted_test_string)

--- a/kordac/tests/assets/beautify/example_inline_code.md
+++ b/kordac/tests/assets/beautify/example_inline_code.md
@@ -1,0 +1,1 @@
+Here is a fragment of code that is important: `string = "Hello World"` and the formatting is unchanged.

--- a/kordac/tests/assets/beautify/example_inline_code_expected.html
+++ b/kordac/tests/assets/beautify/example_inline_code_expected.html
@@ -1,0 +1,3 @@
+<p>
+ Here is a fragment of code that is important: <code>string = "Hello World"</code> and the formatting is unchanged.
+</p>

--- a/kordac/tests/assets/beautify/example_mixed_code_types.md
+++ b/kordac/tests/assets/beautify/example_mixed_code_types.md
@@ -3,3 +3,5 @@ Here is a fragment of code that is important: `string = "Hello World"` and the f
 Here is another fragment of code that is important:
 
     string = "Hello Jack!"
+
+I really hope he sees this.

--- a/kordac/tests/assets/beautify/example_mixed_code_types.md
+++ b/kordac/tests/assets/beautify/example_mixed_code_types.md
@@ -1,0 +1,5 @@
+Here is a fragment of code that is important: `string = "Hello World"` and the formatting is unchanged.
+
+Here is another fragment of code that is important:
+
+    string = "Hello Jack!"

--- a/kordac/tests/assets/beautify/example_mixed_code_types_expected.html
+++ b/kordac/tests/assets/beautify/example_mixed_code_types_expected.html
@@ -1,0 +1,8 @@
+<p>
+ Here is a fragment of code that is important: <code>string = "Hello World"</code> and the formatting is unchanged.
+</p>
+<p>
+ Here is another fragment of code that is important:
+</p>
+<pre><code>string = &quot;Hello Jack!&quot;
+</code></pre>

--- a/kordac/tests/assets/beautify/example_mixed_code_types_expected.html
+++ b/kordac/tests/assets/beautify/example_mixed_code_types_expected.html
@@ -6,3 +6,6 @@
 </p>
 <pre><code>string = &quot;Hello Jack!&quot;
 </code></pre>
+<p>
+ I really hope he sees this.
+</p>

--- a/kordac/tests/assets/beautify/example_preformatted_code.md
+++ b/kordac/tests/assets/beautify/example_preformatted_code.md
@@ -1,0 +1,3 @@
+Here is a fragment of code that is important:
+
+    string = "Hello World!"

--- a/kordac/tests/assets/beautify/example_preformatted_code_expected.html
+++ b/kordac/tests/assets/beautify/example_preformatted_code_expected.html
@@ -1,0 +1,5 @@
+<p>
+ Here is a fragment of code that is important:
+</p>
+<pre><code>string = "Hello World!"
+</code></pre>

--- a/kordac/tests/assets/beautify/example_preformatted_code_with_extension.md
+++ b/kordac/tests/assets/beautify/example_preformatted_code_with_extension.md
@@ -1,0 +1,4 @@
+Here is a fragment of code that is important:
+```
+string = "Hello World!"
+```

--- a/kordac/tests/assets/beautify/example_preformatted_code_with_extension_expected.html
+++ b/kordac/tests/assets/beautify/example_preformatted_code_with_extension_expected.html
@@ -1,0 +1,5 @@
+<p>
+ Here is a fragment of code that is important:
+</p>
+<pre><code>string = &quot;Hello World!&quot;
+</code></pre>

--- a/kordac/tests/assets/beautify/example_preformatted_code_with_extension_expected.html
+++ b/kordac/tests/assets/beautify/example_preformatted_code_with_extension_expected.html
@@ -1,5 +1,5 @@
 <p>
  Here is a fragment of code that is important:
 </p>
-<pre><code>string = &quot;Hello World!&quot;
+<pre><code>string = "Hello World!"
 </code></pre>

--- a/kordac/tests/start_tests.py
+++ b/kordac/tests/start_tests.py
@@ -94,5 +94,5 @@ if __name__ == '__main__':
         unit_result = runner.run(unit_suite())
         print()
 
-    if (smoke_result is not None and not system_result.wasSuccessful()) or (system_result is not None and not system_result.wasSuccessful()) or (unit_result is not None and not unit_result.wasSuccessful()):
+    if (smoke_result is not None and not smoke_result.wasSuccessful()) or (system_result is not None and not system_result.wasSuccessful()) or (unit_result is not None and not unit_result.wasSuccessful()):
         sys.exit(1)

--- a/kordac/tests/start_tests.py
+++ b/kordac/tests/start_tests.py
@@ -19,6 +19,7 @@ from kordac.tests.ConditionalTest import ConditionalTest
 from kordac.tests.FrameTest import FrameTest
 from kordac.tests.TableOfContentsTest import TableOfContentsTest
 from kordac.tests.ScratchTest import ScratchTest
+from kordac.tests.BeautifyTest import BeautifyTest
 
 def parse_args():
     opts = optparse.OptionParser(
@@ -64,7 +65,8 @@ def unit_suite():
         unittest.makeSuite(ConditionalTest),
         unittest.makeSuite(FrameTest),
         unittest.makeSuite(TableOfContentsTest),
-        unittest.makeSuite(ScratchTest)
+        unittest.makeSuite(ScratchTest),
+        unittest.makeSuite(BeautifyTest)
     ))
 
 if __name__ == '__main__':


### PR DESCRIPTION
fixes #136 

I have chosen this solution as beautify still gives us the most consistent and readable output compared to some other methods of (quickly) prettifying. 